### PR TITLE
Add check for unrooted Entrypoints

### DIFF
--- a/Microsoft.NET.Build.Containers/CreateNewImage.cs
+++ b/Microsoft.NET.Build.Containers/CreateNewImage.cs
@@ -111,22 +111,7 @@ public class CreateNewImage : Microsoft.Build.Utilities.Task
         image.AddLayer(newLayer);
         image.WorkingDirectory = WorkingDirectory;
 
-        string[] entryPoint = Entrypoint.Select(i => i.ItemSpec).ToArray();
-
-        // The SelfContained scenario: /path/to/appname
-        if (entryPoint.Length == 1)
-        {
-            if (!Path.IsPathRooted(entryPoint[0]))
-            {
-                if (BuildEngine != null)
-                {
-                    Log.LogWarning($"Entrypoint '{entryPoint[0]}' should be a fully rooted path. Attempting to root to $(ContainerWorkingDirectory): {WorkingDirectory}");
-                }
-                entryPoint[0] = Path.Combine(WorkingDirectory, entryPoint[0]);
-            }
-        }
-
-        image.SetEntrypoint(entryPoint, EntrypointArgs.Select(i => i.ItemSpec).ToArray());
+        image.SetEntrypoint(Entrypoint.Select(i => i.ItemSpec).ToArray(), EntrypointArgs.Select(i => i.ItemSpec).ToArray());
 
         if (OutputRegistry.StartsWith("docker://"))
         {

--- a/Microsoft.NET.Build.Containers/ParseContainerProperties.cs
+++ b/Microsoft.NET.Build.Containers/ParseContainerProperties.cs
@@ -148,7 +148,7 @@ public class ParseContainerProperties : Microsoft.Build.Utilities.Task
             {
                 if (BuildEngine != null)
                 {
-                    Log.LogWarning($"{nameof(ContainerEntrypoint)} '{ContainerEntrypoint[0].ItemSpec[0]}' should be a fully rooted path. {nameof(ContainerEntrypoint)} will be rooted to {nameof(ContainerWorkingDirectory)}: '{ContainerWorkingDirectory}'");
+                    Log.LogWarning($"{nameof(ContainerEntrypoint)} '{ContainerEntrypoint[0].ItemSpec}' should be a fully rooted path. {nameof(ContainerEntrypoint)} will be rooted to {nameof(ContainerWorkingDirectory)}: '{ContainerWorkingDirectory}'");
                 }
                 NewContainerEntrypoint = new ITaskItem[] { new TaskItem(Path.Combine(ContainerWorkingDirectory, ContainerEntrypoint[0].ItemSpec)) };
             }

--- a/Microsoft.NET.Build.Containers/build/Microsoft.NET.Build.Containers.targets
+++ b/Microsoft.NET.Build.Containers/build/Microsoft.NET.Build.Containers.targets
@@ -45,7 +45,9 @@
         <ParseContainerProperties FullyQualifiedBaseImageName="$(ContainerBaseImage)"
                                   ContainerRegistry="$(ContainerRegistry)"
                                   ContainerImageName="$(ContainerImageName)"
-                                  ContainerImageTag="$(ContainerImageTag)">
+                                  ContainerImageTag="$(ContainerImageTag)"
+                                  ContainerEntrypoint="$(ContainerEntrypoint)"
+                                  ContainerWorkingDirectory="$(ContainerWorkingDirectory)">
 
             <Output TaskParameter="ParsedContainerRegistry" PropertyName="ContainerBaseRegistry" />
             <Output TaskParameter="ParsedContainerImage" PropertyName="ContainerBaseName" />
@@ -53,6 +55,7 @@
             <Output TaskParameter="NewContainerRegistry" PropertyName="ContainerRegistry" />
             <Output TaskParameter="NewContainerImageName" PropertyName="ContainerImageName" />
             <Output TaskParameter="NewContainerTag" PropertyName="ContainerImageTag" />
+            <Output TaskParameter="NewContainerEntrypoint" ItemName="ContainerEntrypoint" />
         </ParseContainerProperties>
     </Target>
 


### PR DESCRIPTION
WIP to fix https://github.com/rainersigwald/containers/issues/44

Questions:
- [ ] Should we catch this in ParseContainerProps or CreateNewImage?
	My thought is in CreateNewImage, since the info is conveniently there. Maybe parsecontainerprops can log a warning, and createnewimage does the path combining.