### PR TITLE
Add a build error if building on an unsupported SDK

### DIFF
--- a/Microsoft.NET.Build.Containers/build/Microsoft.NET.Build.Containers.targets
+++ b/Microsoft.NET.Build.Containers/build/Microsoft.NET.Build.Containers.targets
@@ -1,9 +1,16 @@
 <Project>
-    <Target Name="_ContainerVerifySDKVersion">
+    <Target Name="_ContainerVerifySDKVersion"
+        Condition="'$(WebPublishMethod)' == 'Container' or '$(PublishProfile)' == 'DefaultContainer'"
+        BeforeTargets="AfterPublish">
+        <!-- If the user has opted into container publishing via their own profile (WebPublishMethod = Container) or
+            via the default Profile (PublishProfile = DefaultContainer), make sure they're on a supported SDK version.
+            We do the explicit profile name check here because for preview6 for example the profile didn't exist, so we
+            can't rely only on the WebPublishMethod. -->
         <PropertyGroup>
-            <_IsAllowedVersion Condition="$(NETCoreSdkVersion.StartsWith('7.0.100-preview.7')) or $(NETCoreSdkVersion.StartsWith('7.0.100-rc')) or $(NETCoreSdkVersion.StartsWith('7.0.100'))">true</_IsAllowedVersion>
+            <!-- Allow preview 7, any RC, or any stable version of 7 -->
+            <_IsAllowedVersion Condition="$(NETCoreSdkVersion.StartsWith('7.0.100-preview.7')) or $(NETCoreSdkVersion.StartsWith('7.0.100-rc')) or ($(NETCoreSdkVersion.StartsWith('7.0.10')) and $(NETCoreSdkVersion.Contains('-')) == false)">true</_IsAllowedVersion>
         </PropertyGroup>
-        <Error Code="CONTAINER002" Text="The current .NET SDK \($(NETCoreSdkVersion)\) doesn't support containerization. Please use version 7.0.100-preview.7 or higher." />
+        <Error Condition="'$(_IsAllowedVersion)' != 'true'" Code="CONTAINER002" Text="The current .NET SDK ($(NETCoreSdkVersion)) doesn't support containerization. Please use version 7.0.100-preview.7 or higher." />
     </Target>
 
     <Target Name="ComputeContainerConfig">

--- a/Microsoft.NET.Build.Containers/build/Microsoft.NET.Build.Containers.targets
+++ b/Microsoft.NET.Build.Containers/build/Microsoft.NET.Build.Containers.targets
@@ -1,4 +1,11 @@
 <Project>
+    <Target Name="_ContainerVerifySDKVersion">
+        <PropertyGroup>
+            <_IsAllowedVersion Condition="$(NETCoreSdkVersion.StartsWith('7.0.100-preview.7')) or $(NETCoreSdkVersion.StartsWith('7.0.100-rc')) or $(NETCoreSdkVersion.StartsWith('7.0.100'))">true</_IsAllowedVersion>
+        </PropertyGroup>
+        <Error Code="CONTAINER002" Text="The current .NET SDK \($(NETCoreSdkVersion)\) doesn't support containerization. Please use version 7.0.100-preview.7 or higher." />
+    </Target>
+
     <Target Name="ComputeContainerConfig">
         <!-- Reference data about this project -->
         <PropertyGroup>
@@ -58,6 +65,7 @@
 
     <PropertyGroup>
         <PublishContainerDependsOn>
+            _ContainerVerifySDKVersion;
             ComputeContainerConfig
         </PublishContainerDependsOn>
     </PropertyGroup>


### PR DESCRIPTION
If a user explicitly asks for containerization we should be able to tell them if it's not supported.

Strictly speaking this means that they need to be on 7.0.100-preview.7 or higher.

If they are using a custom publish profile, they will have set the WebPublishMethod explicitly, so we can check that to cover that case. If they are using the default publish profile, they will never actually load the nonexistent profile on unsupported SDK versions, so we should check for the explicit use of the default profile.