### PR TITLE
Correct package metadata to enable publishing

### DIFF
--- a/Microsoft.NET.Build.Containers/Microsoft.NET.Build.Containers.csproj
+++ b/Microsoft.NET.Build.Containers/Microsoft.NET.Build.Containers.csproj
@@ -19,10 +19,10 @@
 
     <!-- MSBuild tasks shouldn't be referenced. This is by design. -->
     <NoWarn>NU5100;NU5128</NoWarn>
-    <Authors>Rainer Sigwald, Ben Villalobos, Chet Husk</Authors>
+    <Authors>Microsoft</Authors>
     <Company>Microsoft</Company>
     <Description>Tasks and targets to natively publish .NET applications as containers.</Description>
-    <Copyright></Copyright>
+    <Copyright>&#169; Microsoft Corporation. All rights reserved.</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/dotnet/sdk-container-builds</PackageProjectUrl>
     <RepositoryUrl>https://github.com/dotnet/sdk-container-builds</RepositoryUrl>


### PR DESCRIPTION
The 0.1.6 package couldn't be pushed to NuGet due to invalid MS metadata. I consulted the docs and updated the values to the correct ones.  Once this is merged I'll sync to the internal repo and trigger another signed build.