### PR TITLE
Support building multiple tags at once

### DIFF
--- a/Microsoft.NET.Build.Containers/ParseContainerProperties.cs
+++ b/Microsoft.NET.Build.Containers/ParseContainerProperties.cs
@@ -94,9 +94,9 @@ public class ParseContainerProperties : Microsoft.Build.Utilities.Task
         {
             if (invalids.Any()) {
                 if (invalids.Length == 1) {
-                    Log.LogError($"Invalid {nameof(ContainerImageTag)} provided: {0}. {nameof(ContainerImageTag)} must be a semicolon-delimited list of valid image tags. Image tags must be alphanumeric, underscore, hyphen, or period.", invalids[0]);
+                    Log.LogError(null, "CONTAINER003", "Container.InvalidTag", null, 0, 0, 0, 0, $"Invalid {nameof(ContainerImageTag)} provided: {0}. {nameof(ContainerImageTag)} must be a semicolon-delimited list of valid image tags. Image tags must be alphanumeric, underscore, hyphen, or period.", invalids[0]);
                 } else {
-                    Log.LogError($"Invalid {nameof(ContainerImageTag)}s provided: {0}. {nameof(ContainerImageTag)} must be a semicolon-delimited list of valid image tags. Image tags must be alphanumeric, underscore, hyphen, or period.", String.Join(", ", invalids));
+                    Log.LogError(null, "CONTAINER003", "Container.InvalidTag", null, 0, 0, 0, 0, $"Invalid {nameof(ContainerImageTag)}s provided: {0}. {nameof(ContainerImageTag)} must be a semicolon-delimited list of valid image tags. Image tags must be alphanumeric, underscore, hyphen, or period.", String.Join(", ", invalids));
                 }
                 return !Log.HasLoggedErrors;
             }
@@ -141,7 +141,7 @@ public class ParseContainerProperties : Microsoft.Build.Utilities.Task
         {
             if (!ContainerHelpers.NormalizeImageName(ContainerImageName, out string? normalizedImageName))
             {
-                Log.LogWarning(null, "CONTAINER001", null, null, 0, 0, 0, 0, $"{nameof(ContainerImageName)} was not a valid container image name, it was normalized to {normalizedImageName}");
+                Log.LogWarning(null, "CONTAINER001", "Container.InvalidImageName", null, 0, 0, 0, 0, $"{nameof(ContainerImageName)} was not a valid container image name, it was normalized to {normalizedImageName}");
                 NewContainerImageName = normalizedImageName;
             }
             else

--- a/Microsoft.NET.Build.Containers/ParseContainerProperties.cs
+++ b/Microsoft.NET.Build.Containers/ParseContainerProperties.cs
@@ -61,32 +61,23 @@ public class ParseContainerProperties : Microsoft.Build.Utilities.Task
         NewContainerTags = Array.Empty<string>();
     }
 
-    private static bool ParsePropertyAsArray(string input, [NotNullWhen(true)] out string[]? items)
-    {
-        if (String.IsNullOrEmpty(input))
-        {
+    private static bool ParsePropertyAsArray(string input, [NotNullWhen(true)] out string[]? items) {
+        if(String.IsNullOrEmpty(input)) {
             items = null;
             return false;
-        }
-        else
-        {
+        } else {
             items = input.Split(';');
             return true;
         }
     }
 
-    private static bool TryValidateTags(string[] inputTags, out string[] validTags, out string[] invalidTags)
-    {
+    private static bool TryValidateTags(string[] inputTags, out string[] validTags, out string[] invalidTags) {
         var v = new List<string>();
         var i = new List<string>();
-        foreach (var tag in inputTags)
-        {
-            if (ContainerHelpers.IsValidImageTag(tag))
-            {
+        foreach (var tag in inputTags) {
+            if (ContainerHelpers.IsValidImageTag(tag)) {
                 v.Add(tag);
-            }
-            else
-            {
+            } else {
                 i.Add(tag);
             }
         }
@@ -101,22 +92,16 @@ public class ParseContainerProperties : Microsoft.Build.Utilities.Task
         string[] validTags;
         if (!string.IsNullOrEmpty(ContainerImageTag) && ParsePropertyAsArray(ContainerImageTag, out var inputTags) && !TryValidateTags(inputTags, out var valids, out var invalids))
         {
-            if (invalids.Any())
-            {
-                if (invalids.Length == 1)
-                {
+            if (invalids.Any()) {
+                if (invalids.Length == 1) {
                     Log.LogError($"Invalid {nameof(ContainerImageTag)} provided: {0}. {nameof(ContainerImageTag)} must be a semicolon-delimited list of valid image tags. Image tags must be alphanumeric, underscore, hyphen, or period.", invalids[0]);
-                }
-                else
-                {
+                } else {
                     Log.LogError($"Invalid {nameof(ContainerImageTag)}s provided: {0}. {nameof(ContainerImageTag)} must be a semicolon-delimited list of valid image tags. Image tags must be alphanumeric, underscore, hyphen, or period.", String.Join(", ", invalids));
                 }
                 return !Log.HasLoggedErrors;
             }
             validTags = invalids;
-        }
-        else
-        {
+        } else {
             validTags = Array.Empty<string>();
         }
 

--- a/Microsoft.NET.Build.Containers/ParseContainerProperties.cs
+++ b/Microsoft.NET.Build.Containers/ParseContainerProperties.cs
@@ -100,7 +100,7 @@ public class ParseContainerProperties : Microsoft.Build.Utilities.Task
                 }
                 return !Log.HasLoggedErrors;
             }
-            validTags = invalids;
+            validTags = valids;
         } else {
             validTags = Array.Empty<string>();
         }

--- a/Microsoft.NET.Build.Containers/build/Microsoft.NET.Build.Containers.targets
+++ b/Microsoft.NET.Build.Containers/build/Microsoft.NET.Build.Containers.targets
@@ -71,7 +71,7 @@
                         BaseImageTag="$(ContainerBaseTag)"
                         OutputRegistry="$(ContainerRegistry)"
                         ImageName="$(ContainerImageName)"
-                        ImageTags="$(ContainerImageTags)"
+                        ImageTags="@(ContainerImageTags)"
                         PublishDirectory="$(PublishDir)"
                         WorkingDirectory="$(ContainerWorkingDirectory)"
                         Entrypoint="@(ContainerEntrypoint)"

--- a/Microsoft.NET.Build.Containers/build/Microsoft.NET.Build.Containers.targets
+++ b/Microsoft.NET.Build.Containers/build/Microsoft.NET.Build.Containers.targets
@@ -21,7 +21,8 @@
             <ContainerRegistry Condition="'$(ContainerRegistry)' == ''">docker://</ContainerRegistry>
             <!-- Note: spaces will be replaced with '-' in ContainerImageName and ContainerImageTag -->
             <ContainerImageName Condition="'$(ContainerImageName)' == ''">$(AssemblyName)</ContainerImageName>
-            <ContainerImageTag Condition="'$(ContainerImageTag)' == ''">$(Version)</ContainerImageTag>
+            <!-- Only default a tag name if no tag names at all are provided -->
+            <ContainerImageTag Condition="'$(ContainerImageTag)' == '' and '$(ContainerImageTags)' == ''">$(Version)</ContainerImageTag>
             <ContainerWorkingDirectory Condition="'$(ContainerWorkingDirectory)' == ''">/app</ContainerWorkingDirectory>
             <!-- Could be semicolon-delimited -->
         </PropertyGroup>
@@ -48,7 +49,8 @@
         <ParseContainerProperties FullyQualifiedBaseImageName="$(ContainerBaseImage)"
                                   ContainerRegistry="$(ContainerRegistry)"
                                   ContainerImageName="$(ContainerImageName)"
-                                  ContainerImageTag="$(ContainerImageTag)">
+                                  ContainerImageTag="$(ContainerImageTag)"
+                                  ContainerImageTags="$(ContainerImageTags)">
 
             <Output TaskParameter="ParsedContainerRegistry" PropertyName="ContainerBaseRegistry" />
             <Output TaskParameter="ParsedContainerImage" PropertyName="ContainerBaseName" />

--- a/Microsoft.NET.Build.Containers/build/Microsoft.NET.Build.Containers.targets
+++ b/Microsoft.NET.Build.Containers/build/Microsoft.NET.Build.Containers.targets
@@ -55,7 +55,7 @@
             <Output TaskParameter="ParsedContainerTag" PropertyName="ContainerBaseTag" />
             <Output TaskParameter="NewContainerRegistry" PropertyName="ContainerRegistry" />
             <Output TaskParameter="NewContainerImageName" PropertyName="ContainerImageName" />
-            <Output TaskParameter="NewContainerTag" PropertyName="ContainerImageTag" />
+            <Output TaskParameter="NewContainerTags" ItemName="ContainerImageTags" />
         </ParseContainerProperties>
     </Target>
 
@@ -71,7 +71,7 @@
                         BaseImageTag="$(ContainerBaseTag)"
                         OutputRegistry="$(ContainerRegistry)"
                         ImageName="$(ContainerImageName)"
-                        ImageTag="$(ContainerImageTag)"
+                        ImageTags="$(ContainerImageTags)"
                         PublishDirectory="$(PublishDir)"
                         WorkingDirectory="$(ContainerWorkingDirectory)"
                         Entrypoint="@(ContainerEntrypoint)"

--- a/Test.Microsoft.NET.Build.Containers.Filesystem/CreateNewImageTests.cs
+++ b/Test.Microsoft.NET.Build.Containers.Filesystem/CreateNewImageTests.cs
@@ -93,7 +93,7 @@ public class CreateNewImageTests
         pcp.FullyQualifiedBaseImageName = "https://mcr.microsoft.com/dotnet/runtime:6.0";
         pcp.ContainerRegistry = "http://localhost:5010";
         pcp.ContainerImageName = "dotnet/testimage";
-        pcp.ContainerImageTag = new [] {"5.0", "latest"};
+        pcp.ContainerImageTags = new [] {"5.0", "latest"};
 
         Assert.IsTrue(pcp.Execute());
         Assert.AreEqual("https://mcr.microsoft.com", pcp.ParsedContainerRegistry);

--- a/Test.Microsoft.NET.Build.Containers.Filesystem/CreateNewImageTests.cs
+++ b/Test.Microsoft.NET.Build.Containers.Filesystem/CreateNewImageTests.cs
@@ -101,7 +101,7 @@ public class CreateNewImageTests
         Assert.AreEqual("6.0", pcp.ParsedContainerTag);
 
         Assert.AreEqual("dotnet/testimage", pcp.NewContainerImageName);
-        Assert.AreEqual("5.0", pcp.NewContainerTag);
+        new []{ "5.0"}.SequenceEqual(pcp.NewContainerTags);
 
         CreateNewImage cni = new CreateNewImage();
         cni.BaseRegistry = pcp.ParsedContainerRegistry;

--- a/Test.Microsoft.NET.Build.Containers.Filesystem/CreateNewImageTests.cs
+++ b/Test.Microsoft.NET.Build.Containers.Filesystem/CreateNewImageTests.cs
@@ -93,7 +93,7 @@ public class CreateNewImageTests
         pcp.FullyQualifiedBaseImageName = "https://mcr.microsoft.com/dotnet/runtime:6.0";
         pcp.ContainerRegistry = "http://localhost:5010";
         pcp.ContainerImageName = "dotnet/testimage";
-        pcp.ContainerImageTag = "5.0;latest";
+        pcp.ContainerImageTag = new [] {"5.0", "latest"};
 
         Assert.IsTrue(pcp.Execute());
         Assert.AreEqual("https://mcr.microsoft.com", pcp.ParsedContainerRegistry);

--- a/Test.Microsoft.NET.Build.Containers.Filesystem/CreateNewImageTests.cs
+++ b/Test.Microsoft.NET.Build.Containers.Filesystem/CreateNewImageTests.cs
@@ -93,7 +93,7 @@ public class CreateNewImageTests
         pcp.FullyQualifiedBaseImageName = "https://mcr.microsoft.com/dotnet/runtime:6.0";
         pcp.ContainerRegistry = "http://localhost:5010";
         pcp.ContainerImageName = "dotnet/testimage";
-        pcp.ContainerImageTag = "5.0";
+        pcp.ContainerImageTag = "5.0;latest";
 
         Assert.IsTrue(pcp.Execute());
         Assert.AreEqual("https://mcr.microsoft.com", pcp.ParsedContainerRegistry);
@@ -101,7 +101,7 @@ public class CreateNewImageTests
         Assert.AreEqual("6.0", pcp.ParsedContainerTag);
 
         Assert.AreEqual("dotnet/testimage", pcp.NewContainerImageName);
-        new []{ "5.0"}.SequenceEqual(pcp.NewContainerTags);
+        new []{ "5.0", "latest"}.SequenceEqual(pcp.NewContainerTags);
 
         CreateNewImage cni = new CreateNewImage();
         cni.BaseRegistry = pcp.ParsedContainerRegistry;
@@ -112,6 +112,7 @@ public class CreateNewImageTests
         cni.PublishDirectory = Path.Combine(newProjectDir.FullName, "bin", "release", "net7.0");
         cni.WorkingDirectory = "app/";
         cni.Entrypoint = new TaskItem[] { new("ParseContainerProperties_EndToEnd") };
+        cni.ImageTags = pcp.NewContainerTags;
 
         Assert.IsTrue(cni.Execute());
         newProjectDir.Delete(true);

--- a/Test.Microsoft.NET.Build.Containers.Filesystem/ParseContainerPropertiesTests.cs
+++ b/Test.Microsoft.NET.Build.Containers.Filesystem/ParseContainerPropertiesTests.cs
@@ -23,7 +23,7 @@ namespace Test.Microsoft.NET.Build.Containers.Tasks
             Assert.AreEqual("6.0", task.ParsedContainerTag);
 
             Assert.AreEqual("dotnet/testimage", task.NewContainerImageName);
-            Assert.AreEqual("5.0", task.NewContainerTag);
+            new[] { "5.0" }.SequenceEqual(task.NewContainerTags);
         }
 
         [TestMethod]
@@ -42,7 +42,7 @@ namespace Test.Microsoft.NET.Build.Containers.Tasks
 
             Assert.AreEqual("http://localhost:5010", task.NewContainerRegistry);
             Assert.AreEqual("dotnet/testimage", task.NewContainerImageName);
-            Assert.AreEqual("5.0", task.NewContainerTag);
+            new[] { "5.0" }.SequenceEqual(task.NewContainerTags);
         }
 
         [TestMethod]
@@ -61,7 +61,7 @@ namespace Test.Microsoft.NET.Build.Containers.Tasks
 
             Assert.AreEqual("https://localhost:5010", task.NewContainerRegistry);
             Assert.AreEqual("dotnet/testimage", task.NewContainerImageName);
-            Assert.AreEqual("5.0", task.NewContainerTag);
+            new[] { "5.0" }.SequenceEqual(task.NewContainerTags);
         }
 
         [TestMethod]
@@ -81,7 +81,7 @@ namespace Test.Microsoft.NET.Build.Containers.Tasks
             Assert.AreEqual("6-0", task.ParsedContainerTag);
 
             Assert.AreEqual("dotnet/testimage", task.NewContainerImageName);
-            Assert.AreEqual("5.0", task.NewContainerTag);
+            new[] { "5.0" }.SequenceEqual(task.NewContainerTags);
         }
 
         [TestMethod]

--- a/Test.Microsoft.NET.Build.Containers.Filesystem/ParseContainerPropertiesTests.cs
+++ b/Test.Microsoft.NET.Build.Containers.Filesystem/ParseContainerPropertiesTests.cs
@@ -15,7 +15,7 @@ namespace Test.Microsoft.NET.Build.Containers.Tasks
             task.FullyQualifiedBaseImageName = "https://mcr.microsoft.com/dotnet/runtime:6.0";
             task.ContainerRegistry = "http://localhost:5010";
             task.ContainerImageName = "dotnet/testimage";
-            task.ContainerImageTag = "5.0";
+            task.ContainerImageTag = new[] { "5.0" };
 
             Assert.IsTrue(task.Execute());
             Assert.AreEqual("https://mcr.microsoft.com", task.ParsedContainerRegistry);
@@ -33,7 +33,7 @@ namespace Test.Microsoft.NET.Build.Containers.Tasks
             task.FullyQualifiedBaseImageName = "mcr.microsoft.com/dotnet/runtime:6.0";
             task.ContainerRegistry = "http://localhost:5010";
             task.ContainerImageName = "dotnet/testimage";
-            task.ContainerImageTag = "5.0";
+            task.ContainerImageTag = new[] { "5.0" };
 
             Assert.IsTrue(task.Execute());
             Assert.AreEqual("https://mcr.microsoft.com", task.ParsedContainerRegistry);
@@ -52,7 +52,7 @@ namespace Test.Microsoft.NET.Build.Containers.Tasks
             task.FullyQualifiedBaseImageName = "mcr.microsoft.com/dotnet/runtime:6.0";
             task.ContainerRegistry = "localhost:5010";
             task.ContainerImageName = "dotnet/testimage";
-            task.ContainerImageTag = "5.0";
+            task.ContainerImageTag = new[] { "5.0" };
 
             Assert.IsTrue(task.Execute());
             Assert.AreEqual("https://mcr.microsoft.com", task.ParsedContainerRegistry);
@@ -73,7 +73,7 @@ namespace Test.Microsoft.NET.Build.Containers.Tasks
 
             // Spaces in the "new" container info don't pass the regex.
             task.ContainerImageName = "dotnet/testimage";
-            task.ContainerImageTag = "5.0";
+            task.ContainerImageTag = new[] { "5.0" };
 
             Assert.IsTrue(task.Execute());
             Assert.AreEqual("https://mcr-microsoft-com", task.ParsedContainerRegistry);
@@ -94,7 +94,7 @@ namespace Test.Microsoft.NET.Build.Containers.Tasks
 
             // Spaces in the "new" container info don't pass the regex.
             task.ContainerImageName = "dotnet testimage";
-            task.ContainerImageTag = "5.0";
+            task.ContainerImageTag = new[] { "5.0" };
 
             Assert.IsFalse(task.Execute());
             // To do: Verify output contains expected error
@@ -109,7 +109,7 @@ namespace Test.Microsoft.NET.Build.Containers.Tasks
             task.ContainerRegistry = "http://localhost:5010";
             // Spaces in the "new" container info don't pass the regex.
             task.ContainerImageName = "dotnet/testimage";
-            task.ContainerImageTag = "5 0";
+            task.ContainerImageTag = new[] { "5.0" };
 
             Assert.IsFalse(task.Execute());
             // To do: Verify output contains expected error

--- a/Test.Microsoft.NET.Build.Containers.Filesystem/ParseContainerPropertiesTests.cs
+++ b/Test.Microsoft.NET.Build.Containers.Filesystem/ParseContainerPropertiesTests.cs
@@ -15,7 +15,7 @@ namespace Test.Microsoft.NET.Build.Containers.Tasks
             task.FullyQualifiedBaseImageName = "https://mcr.microsoft.com/dotnet/runtime:6.0";
             task.ContainerRegistry = "http://localhost:5010";
             task.ContainerImageName = "dotnet/testimage";
-            task.ContainerImageTag = new[] { "5.0" };
+            task.ContainerImageTags = new[] { "5.0" };
 
             Assert.IsTrue(task.Execute());
             Assert.AreEqual("https://mcr.microsoft.com", task.ParsedContainerRegistry);
@@ -33,7 +33,7 @@ namespace Test.Microsoft.NET.Build.Containers.Tasks
             task.FullyQualifiedBaseImageName = "mcr.microsoft.com/dotnet/runtime:6.0";
             task.ContainerRegistry = "http://localhost:5010";
             task.ContainerImageName = "dotnet/testimage";
-            task.ContainerImageTag = new[] { "5.0" };
+            task.ContainerImageTags = new[] { "5.0" };
 
             Assert.IsTrue(task.Execute());
             Assert.AreEqual("https://mcr.microsoft.com", task.ParsedContainerRegistry);
@@ -52,7 +52,7 @@ namespace Test.Microsoft.NET.Build.Containers.Tasks
             task.FullyQualifiedBaseImageName = "mcr.microsoft.com/dotnet/runtime:6.0";
             task.ContainerRegistry = "localhost:5010";
             task.ContainerImageName = "dotnet/testimage";
-            task.ContainerImageTag = new[] { "5.0" };
+            task.ContainerImageTags = new[] { "5.0" };
 
             Assert.IsTrue(task.Execute());
             Assert.AreEqual("https://mcr.microsoft.com", task.ParsedContainerRegistry);
@@ -73,7 +73,7 @@ namespace Test.Microsoft.NET.Build.Containers.Tasks
 
             // Spaces in the "new" container info don't pass the regex.
             task.ContainerImageName = "dotnet/testimage";
-            task.ContainerImageTag = new[] { "5.0" };
+            task.ContainerImageTags = new[] { "5.0" };
 
             Assert.IsTrue(task.Execute());
             Assert.AreEqual("https://mcr-microsoft-com", task.ParsedContainerRegistry);
@@ -94,7 +94,7 @@ namespace Test.Microsoft.NET.Build.Containers.Tasks
 
             // Spaces in the "new" container info don't pass the regex.
             task.ContainerImageName = "dotnet testimage";
-            task.ContainerImageTag = new[] { "5.0" };
+            task.ContainerImageTags = new[] { "5.0" };
 
             Assert.IsFalse(task.Execute());
             // To do: Verify output contains expected error
@@ -109,7 +109,23 @@ namespace Test.Microsoft.NET.Build.Containers.Tasks
             task.ContainerRegistry = "http://localhost:5010";
             // Spaces in the "new" container info don't pass the regex.
             task.ContainerImageName = "dotnet/testimage";
-            task.ContainerImageTag = new[] { "5.0" };
+            task.ContainerImageTags = new[] { "5.0" };
+
+            Assert.IsFalse(task.Execute());
+            // To do: Verify output contains expected error
+        }
+
+        [TestMethod]
+        [Ignore("Task logging in tests unsupported.")]
+        public void CanOnlySupplyOneOfTagAndTags()
+        {
+            ParseContainerProperties task = new ParseContainerProperties();
+            task.FullyQualifiedBaseImageName = "mcr.microsoft.com/dotnet/runtime:6 0";
+            task.ContainerRegistry = "http://localhost:5010";
+            // Spaces in the "new" container info don't pass the regex.
+            task.ContainerImageName = "dotnet/testimage";
+            task.ContainerImageTag = "a.b";
+            task.ContainerImageTags = new[] { "5.0" };
 
             Assert.IsFalse(task.Execute());
             // To do: Verify output contains expected error

--- a/docs/ContainerCustomization.md
+++ b/docs/ContainerCustomization.md
@@ -51,15 +51,20 @@ By default, the value used will be the `AssemblyName` of the project.
 > **Note**
 > Image names can only contain lowercase alphanumeric characters, periods, underscores, and dashes, and must start with a letter or number - any other characters will result in an error being thrown.
 
-## ContainerImageTag
+## ContainerImageTag(s)
 
-This property controls the tag that is generated for the image. Tags are often used to refer to different versions of an application, but they can also refer to different operating system distributions, or even just different baked-in configuration.
+This property controls the tag that is generated for the image. Tags are often used to refer to different versions of an application, but they can also refer to different operating system distributions, or even just different baked-in configuration. This property also can be used to push multiple tags - simply use a semicolon-delimited set of tags in the `ContainerImageTags` property, similar to setting multiple `TargetFrameworks`.
 
 By default, the value used will be the `Version` of the project.
 
 ```xml
 <ContainerImageTag>1.2.3-alpha2</ContainerImageTag>
 ```
+
+```xml
+<ContainerImageTags>1.2.3-alpha2;latest</ContainerImageTags>
+```
+
 
 > **Note**
 > Tags can only contain up to 127 alphanumeric characters, periods, underscores, and dashes. They must start with an alphanumeric character or an underscore. Any other form will result in an error being thrown.


### PR DESCRIPTION
Closes #137 

This parses the user's input tags as a semicolon-delimited list, and then iterates through that list during image Push - which should be slow for the first tag and much faster for subsequent tags.  Each tag is validated individually and errors are reported for the incorrect ones only.