### PR TITLE
Merge final 0.1.8 commit to main

### DIFF
--- a/Microsoft.NET.Build.Containers/Microsoft.NET.Build.Containers.csproj
+++ b/Microsoft.NET.Build.Containers/Microsoft.NET.Build.Containers.csproj
@@ -19,10 +19,10 @@
 
     <!-- MSBuild tasks shouldn't be referenced. This is by design. -->
     <NoWarn>NU5100;NU5128</NoWarn>
-    <Authors>Rainer Sigwald, Ben Villalobos, Chet Husk</Authors>
+    <Authors>Microsoft</Authors>
     <Company>Microsoft</Company>
     <Description>Tasks and targets to natively publish .NET applications as containers.</Description>
-    <Copyright></Copyright>
+    <Copyright>&#169; Microsoft Corporation. All rights reserved.</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/dotnet/sdk-container-builds</PackageProjectUrl>
     <RepositoryUrl>https://github.com/dotnet/sdk-container-builds</RepositoryUrl>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,7 +29,7 @@ steps:
     solution: '**/*.sln'
     msbuildArchitecture: 'x64'
     configuration: 'Release'
-    msbuildArguments: '-restore -bl:$(Build.StagingDirectory)\ContainersOfficialBuild.binlog -v:minimal'
+    msbuildArguments: '-restore -bl:$(Build.StagingDirectory)\ContainersOfficialBuild.binlog -v:minimal -p:SignType=${{ parameters.SignType }}'
     maximumCpuCount: true
 
 - task: PublishPipelineArtifact@1


### PR DESCRIPTION
- Cherry pick to v0.1 - More correct image name normalization (#119) (#129)
- Fix v0.1 repo url (#134)
- Correct package metadata to enable publishing (#136)
- Plumb signing parameter down to actual build
