### PR TITLE
Embed debug symbols always

### DIFF
--- a/Microsoft.NET.Build.Containers/Microsoft.NET.Build.Containers.csproj
+++ b/Microsoft.NET.Build.Containers/Microsoft.NET.Build.Containers.csproj
@@ -29,6 +29,9 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>containers;docker;Microsoft.NET.Build.Containers</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+
+    <!-- While in prerelease, ship the symbols to everyone all the time. -->
+    <DebugType>embedded</DebugType>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This isn't generally appropriate for production software, but
since we're in an early preview I think we'll get the best bug
reports if .NET can get every bit of information that it can.
