### PR TITLE
Use SHA256 OneShot APIs

### DIFF
--- a/Microsoft.NET.Build.Containers/Image.cs
+++ b/Microsoft.NET.Build.Containers/Image.cs
@@ -152,8 +152,8 @@ public class Image
 
     public static string GetSha(JsonNode json)
     {
-        using SHA256 mySHA256 = SHA256.Create();
-        byte[] hash = mySHA256.ComputeHash(Encoding.UTF8.GetBytes(json.ToJsonString()));
+        Span<byte> hash = stackalloc byte[SHA256.HashSizeInBytes];
+        SHA256.HashData(Encoding.UTF8.GetBytes(json.ToJsonString()), hash);
 
         return Convert.ToHexString(hash).ToLowerInvariant();
     }

--- a/Microsoft.NET.Build.Containers/Layer.cs
+++ b/Microsoft.NET.Build.Containers/Layer.cs
@@ -25,7 +25,7 @@ public record struct Layer
     public static Layer FromFiles(IEnumerable<(string path, string containerPath)> fileList)
     {
         long fileSize;
-        byte[] hash;
+        Span<byte> hash = stackalloc byte[SHA256.HashSizeInBytes];
 
         string tempTarballPath = ContentStore.GetTempFile();
         using (FileStream fs = File.Create(tempTarballPath))
@@ -47,8 +47,7 @@ public record struct Layer
 
             fs.Position = 0;
 
-            using SHA256 mySHA256 = SHA256.Create();
-            hash = mySHA256.ComputeHash(fs);
+            SHA256.HashData(fs, hash);
         }
 
         string contentHash = Convert.ToHexString(hash).ToLowerInvariant();

--- a/Test.Microsoft.NET.Build.Containers.Filesystem/LayerEndToEnd.cs
+++ b/Test.Microsoft.NET.Build.Containers.Filesystem/LayerEndToEnd.cs
@@ -28,10 +28,9 @@ public class LayerEndToEnd
 
         byte[] hashBytes;
 
-        using (SHA256 hasher = SHA256.Create())
         using (FileStream fs = File.OpenRead(l.BackingFile))
         {
-            hashBytes = hasher.ComputeHash(fs);
+            hashBytes = SHA256.HashData(fs);
         }
 
         Assert.AreEqual(Convert.ToHexString(hashBytes), l.Descriptor.Digest.Substring("sha256:".Length), ignoreCase: true);
@@ -67,10 +66,9 @@ public class LayerEndToEnd
 
         byte[] hashBytes;
 
-        using (SHA256 hasher = SHA256.Create())
         using (FileStream fs = File.OpenRead(l.BackingFile))
         {
-            hashBytes = hasher.ComputeHash(fs);
+            hashBytes = SHA256.HashData(fs);
         }
 
         Assert.AreEqual(Convert.ToHexString(hashBytes), l.Descriptor.Digest.Substring("sha256:".Length), ignoreCase: true);


### PR DESCRIPTION
Instead of creating and disposing an intermediate SHA256 object, use the static APIs directly. Also avoid allocating a temporary byte[] on the heap, and instead just stackalloc the hash bytes.