### PR TITLE
Switch to the dotnet-public NuGet feed

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -2,10 +2,10 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
   </packageSources>
   <packageSourceMapping>
-    <packageSource key="nuget.org">
+    <packageSource key="dotnet-public">
       <package pattern="*" />
     </packageSource>
   </packageSourceMapping>


### PR DESCRIPTION
This is required for internal Microsoft compliance reasons.
