### PR TITLE
Avoid doubled error reports in GitHub Actions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -22,6 +22,6 @@ jobs:
           6.0.x
         global-json-file: 'global.json' # in addition to the 6.0 we need for tests, install "latest"
     - name: Build
-      run: dotnet build
+      run: dotnet build --consoleloggerparameters:NoSummary
     - name: Test
       run: dotnet test --no-build --logger GitHubActions

--- a/containerize/Program.cs
+++ b/containerize/Program.cs
@@ -26,7 +26,7 @@ var baseImageNameOpt = new Option<string>(
 var baseImageTagOpt = new Option<string>(
     name: "--baseimagetag",
     description: "The base image tag. Ex: 6.0",
-    getDefaultValue: () => "latest");
+    getDefaultValue: () => "latest")
 
 var outputRegistryOpt = new Option<string>(
     name: "--outputregistry",

--- a/containerize/Program.cs
+++ b/containerize/Program.cs
@@ -26,7 +26,7 @@ var baseImageNameOpt = new Option<string>(
 var baseImageTagOpt = new Option<string>(
     name: "--baseimagetag",
     description: "The base image tag. Ex: 6.0",
-    getDefaultValue: () => "latest")
+    getDefaultValue: () => "latest");
 
 var outputRegistryOpt = new Option<string>(
     name: "--outputregistry",


### PR DESCRIPTION
For example, see https://github.com/dotnet/sdk-container-builds/pull/161/files#diff-591e9731d0a9220c8d3fda878a4680c7fc58191d16d717e16a74b01b23680cfeR22

Compare to the errors from this build:

![image](https://user-images.githubusercontent.com/3347530/191099586-51d49678-9dcb-4ec0-9d5f-f7de233e5277.png)
