### PR TITLE
Check for PublishImageTag in VS land

### DIFF
--- a/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -37,6 +37,7 @@
             <ContainerImageName Condition="'$(ContainerImageName)' == ''">$(AssemblyName)</ContainerImageName>
             <!-- Only default a tag name if no tag names at all are provided -->
             <ContainerImageTag Condition="'$(ContainerImageTag)' == '' and '$(ContainerImageTags)' == ''">$(Version)</ContainerImageTag>
+            <ContainerImageTag Condition="'$(RunningInVisualStudio)' == 'true' and '$(PublishImageTag)' != ''">$(PublishImageTag)</ContainerImageTag>
             <ContainerWorkingDirectory Condition="'$(ContainerWorkingDirectory)' == ''">/app</ContainerWorkingDirectory>
             <!-- Could be semicolon-delimited -->
         </PropertyGroup>


### PR DESCRIPTION
VS has a scenario where `PublishImageTag` is a relevant property and should override our default tag property.

Closes #177 