### PR TITLE
Use prerelease test packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,9 +5,9 @@
     <ItemGroup>
         <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.3.1" />
         <PackageVersion Include="Microsoft.Build" Version="17.3.1" />
-        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.4.0-preview-20220726-02" />
         <PackageVersion Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0" />
-        <PackageVersion Include="MSTest.TestAdapter" Version="2.2.10" />
+        <PackageVersion Include="MSTest.TestAdapter" Version="2.3.0-preview-20220810-02" />
         <PackageVersion Include="MSTest.TestFramework" Version="2.2.10" />
         <PackageVersion Include="Nerdbank.GitVersioning" Version="3.5.109" />
         <PackageVersion Include="coverlet.collector" Version="3.1.2" />


### PR DESCRIPTION
This avoids a component governance alert related to the packages' dependencies. Once the next versions of these GA we don't need to stay on prerelease versions.
