### PR TITLE
AutoGenerateImageTag sets ContainerImageTag to UTCNow

### DIFF
--- a/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -38,6 +38,7 @@
             <!-- Only default a tag name if no tag names at all are provided -->
             <ContainerImageTag Condition="'$(ContainerImageTag)' == '' and '$(ContainerImageTags)' == ''">$(Version)</ContainerImageTag>
             <ContainerImageTag Condition="'$(RunningInVisualStudio)' == 'true' and '$(PublishImageTag)' != ''">$(PublishImageTag)</ContainerImageTag>
+            <ContainerImageTag Condition="'$(RunningInVisualStudio)' == 'true' and '$(PublishImageTag)' == '' and '$(AutoGenerateImageTag)' == 'true'">$([System.DateTime]::UtcNow.ToString('yyyyMMddhhmmss'))</ContainerImageTag>
             <ContainerWorkingDirectory Condition="'$(ContainerWorkingDirectory)' == ''">/app</ContainerWorkingDirectory>
             <!-- Could be semicolon-delimited -->
         </PropertyGroup>

--- a/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -38,7 +38,7 @@
             <!-- Only default a tag name if no tag names at all are provided -->
             <ContainerImageTag Condition="'$(ContainerImageTag)' == '' and '$(ContainerImageTags)' == ''">$(Version)</ContainerImageTag>
             <ContainerImageTag Condition="'$(AutoGenerateImageTag)' == 'true'">$([System.DateTime]::UtcNow.ToString('yyyyMMddhhmmss'))</ContainerImageTag>
-            <ContainerImageTag Condition="'$(RunningInVisualStudio)' == 'true' and '$(PublishImageTag)' != ''">$(PublishImageTag)</ContainerImageTag>
+            <ContainerImageTag Condition="'$(PublishImageTag)' != ''">$(PublishImageTag)</ContainerImageTag>
             <ContainerWorkingDirectory Condition="'$(ContainerWorkingDirectory)' == ''">/app</ContainerWorkingDirectory>
             <!-- Could be semicolon-delimited -->
         </PropertyGroup>

--- a/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -37,8 +37,8 @@
             <ContainerImageName Condition="'$(ContainerImageName)' == ''">$(AssemblyName)</ContainerImageName>
             <!-- Only default a tag name if no tag names at all are provided -->
             <ContainerImageTag Condition="'$(ContainerImageTag)' == '' and '$(ContainerImageTags)' == ''">$(Version)</ContainerImageTag>
+            <ContainerImageTag Condition="'$(AutoGenerateImageTag)' == 'true'">$([System.DateTime]::UtcNow.ToString('yyyyMMddhhmmss'))</ContainerImageTag>
             <ContainerImageTag Condition="'$(RunningInVisualStudio)' == 'true' and '$(PublishImageTag)' != ''">$(PublishImageTag)</ContainerImageTag>
-            <ContainerImageTag Condition="'$(RunningInVisualStudio)' == 'true' and '$(PublishImageTag)' == '' and '$(AutoGenerateImageTag)' == 'true'">$([System.DateTime]::UtcNow.ToString('yyyyMMddhhmmss'))</ContainerImageTag>
             <ContainerWorkingDirectory Condition="'$(ContainerWorkingDirectory)' == ''">/app</ContainerWorkingDirectory>
             <!-- Could be semicolon-delimited -->
         </PropertyGroup>


### PR DESCRIPTION
## Context 
VS scenario compat for auto generating timestamped tags when requested.

When:
- `AutoGenerateImageTag` is `true`
- `PublishImageTag` is empty 
- ~and `RunningInVisualStudio` is `true`~ removed after consulting with @vijayrkn 

Set `ContainerImageTag` to a UTC timestamp of the current time, in the format of: `yyyyMMddhhmmss`