### PR TITLE
Don't download entire blob before moving on

### DIFF
--- a/Microsoft.NET.Build.Containers/Registry.cs
+++ b/Microsoft.NET.Build.Containers/Registry.cs
@@ -73,7 +73,7 @@ public record struct Registry(Uri BaseUri)
 
         using HttpClient client = GetClient();
 
-        var response = await client.GetAsync(new Uri(BaseUri, $"/v2/{name}/blobs/{descriptor.Digest}"));
+        var response = await client.GetAsync(new Uri(BaseUri, $"/v2/{name}/blobs/{descriptor.Digest}"), HttpCompletionOption.ResponseHeadersRead);
 
         response.EnsureSuccessStatusCode();
 


### PR DESCRIPTION
Tell GetAsync to return as soon as headers are read, before content is available,
so the full blob content doesn't have to be in memory and can be streamed to
its destination as it downloads.
