### PR TITLE
centralize VS properties for target image name and tag

### DIFF
--- a/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -30,8 +30,8 @@
         </PropertyGroup>
 
         <PropertyGroup Label="VS defaults">
-            <!-- OutputRegistry is used by existing VS targets for Docker builds - this lets us fill that void -->
-            <ContainerRegistry Condition="'$(OutputRegistry)' != ''">$(OutputRegistry)</ContainerRegistry>
+            <!-- RegistryUrl is used by existing VS targets for Docker builds - this lets us fill that void -->
+            <ContainerRegistry Condition="'$(RegistryUrl)' != ''">$(RegistryUrl)</ContainerRegistry>
             <!-- PublishImageTag is used by existing VS targets for Docker builds - this lets us fill that void -->
             <ContainerImageTag Condition="'$(PublishImageTag)' != ''">$(PublishImageTag)</ContainerImageTag>
         </PropertyGroup>

--- a/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -29,6 +29,13 @@
             <_ContainerBaseImageTag>$(_TargetFrameworkVersionWithoutV)</_ContainerBaseImageTag>
         </PropertyGroup>
 
+        <PropertyGroup Label="VS defaults">
+            <!-- OutputRegistry is used by existing VS targets for Docker builds - this lets us fill that void -->
+            <ContainerRegistry Condition="'$(OutputRegistry)' != ''">$(OutputRegistry)</ContainerRegistry>
+            <!-- PublishImageTag is used by existing VS targets for Docker builds - this lets us fill that void -->
+            <ContainerImageTag Condition="'$(PublishImageTag)' != ''">$(PublishImageTag)</ContainerImageTag>
+        </PropertyGroup>
+
         <!-- Container Defaults -->
         <PropertyGroup>
             <ContainerBaseImage Condition="'$(ContainerBaseImage)' == ''">$(_ContainerBaseRegistry)/$(_ContainerBaseImageName):$(_ContainerBaseImageTag)</ContainerBaseImage>
@@ -38,7 +45,6 @@
             <!-- Only default a tag name if no tag names at all are provided -->
             <ContainerImageTag Condition="'$(ContainerImageTag)' == '' and '$(ContainerImageTags)' == ''">$(Version)</ContainerImageTag>
             <ContainerImageTag Condition="'$(AutoGenerateImageTag)' == 'true'">$([System.DateTime]::UtcNow.ToString('yyyyMMddhhmmss'))</ContainerImageTag>
-            <ContainerImageTag Condition="'$(PublishImageTag)' != ''">$(PublishImageTag)</ContainerImageTag>
             <ContainerWorkingDirectory Condition="'$(ContainerWorkingDirectory)' == ''">/app</ContainerWorkingDirectory>
             <!-- Could be semicolon-delimited -->
         </PropertyGroup>


### PR DESCRIPTION
Fill in target image name as given by @vijayrkn, and centralize all the VS-specific defaults in one location for easier review.