### PR TITLE
Enable loading a base image from local daemons

### DIFF
--- a/Microsoft.NET.Build.Containers/ContainerBuilder.cs
+++ b/Microsoft.NET.Build.Containers/ContainerBuilder.cs
@@ -26,7 +26,7 @@ public static class ContainerBuilder
         img.SetEntrypoint(entrypoint, entrypointArgs);
 
         var isDockerPush = outputRegistry.StartsWith("docker://");
-        Registry? outputReg = isDockerPush ? null : new Registry(new Uri(outputRegistry));
+        Registry? outputReg = isDockerPush ? null : new Registry(new Uri(outputRegistry.StartsWith("localhost") ? $"http://{outputRegistry}": $"https:{outputRegistry}"));
 
         foreach (var label in labels)
         {

--- a/Microsoft.NET.Build.Containers/ContainerBuilder.cs
+++ b/Microsoft.NET.Build.Containers/ContainerBuilder.cs
@@ -29,7 +29,7 @@ public static class ContainerBuilder
 
         img.SetEntrypoint(entrypoint, entrypointArgs);
 
-        var isDockerPush = outputRegistry.StartsWith("docker://");
+        var isDockerPush = outputRegistry == ContainerHelpers.DefaultRegistry;
         Registry? outputReg = isDockerPush ? null : new Registry(ContainerHelpers.TryExpandRegistryToUri(outputRegistry));
 
         foreach (var label in labels)

--- a/Microsoft.NET.Build.Containers/ContainerBuilder.cs
+++ b/Microsoft.NET.Build.Containers/ContainerBuilder.cs
@@ -13,7 +13,7 @@ public static class ContainerBuilder
         Image img;
         if (isDockerPull)
         {
-            img = await LocalDocker.Pull(baseName, baseTag);
+            img = LocalDocker.Pull(baseName, baseTag);
             throw new ArgumentException("Don't know how to pull images from local daemons at the moment");
         } else {
             Registry baseRegistry = new Registry(ContainerHelpers.TryExpandRegistryToUri(registryName));

--- a/Microsoft.NET.Build.Containers/ContainerBuilder.cs
+++ b/Microsoft.NET.Build.Containers/ContainerBuilder.cs
@@ -10,12 +10,16 @@ public static class ContainerBuilder
     public static async Task Containerize(DirectoryInfo folder, string workingDir, string registryName, string baseName, string baseTag, string[] entrypoint, string[] entrypointArgs, string imageName, string[] imageTags, string outputRegistry, string[] labels, Port[] exposedPorts)
     {
         var isDockerPull = registryName.StartsWith(ContainerHelpers.DefaultRegistry);
-        if (isDockerPull) {
+        Image img;
+        if (isDockerPull)
+        {
+            img = await LocalDocker.Pull(baseName, baseTag);
             throw new ArgumentException("Don't know how to pull images from local daemons at the moment");
+        } else {
+            Registry baseRegistry = new Registry(ContainerHelpers.TryExpandRegistryToUri(registryName));
+            img = await baseRegistry.GetImageManifest(baseName, baseTag);
         }
-        Registry baseRegistry = new Registry(ContainerHelpers.TryExpandRegistryToUri(registryName));
-
-        Image img = await baseRegistry.GetImageManifest(baseName, baseTag);
+        
         img.WorkingDirectory = workingDir;
 
         JsonSerializerOptions options = new()

--- a/Microsoft.NET.Build.Containers/ContainerHelpers.cs
+++ b/Microsoft.NET.Build.Containers/ContainerHelpers.cs
@@ -150,6 +150,11 @@ public static class ContainerHelpers
         return anchoredTagRegexp.IsMatch(imageTag);
     }
 
+    public static Uri TryExpandRegistryToUri(string alreadyValidatedDomain) {
+        var prefix = alreadyValidatedDomain.StartsWith("localhost") ? "http" : "https";
+        return new Uri($"{prefix}://{alreadyValidatedDomain}");
+    }
+
     /// <summary>
     /// Parse a fully qualified container name (e.g. https://mcr.microsoft.com/dotnet/runtime:6.0)
     /// Note: Tag not required.

--- a/Microsoft.NET.Build.Containers/ContainerHelpers.cs
+++ b/Microsoft.NET.Build.Containers/ContainerHelpers.cs
@@ -114,7 +114,7 @@ public record Port(int number, PortType type);
 public static class ContainerHelpers
 {
 
-    public static string DefaultRegistry = "docker.io";
+    public const string DefaultRegistry = "docker.io";
 
     /// <summary>
     /// Matches if the string is not lowercase or numeric, or ., _, or -.
@@ -180,7 +180,7 @@ public static class ContainerHelpers
         var nameMatch = anchoredNameRegexp.Match(referenceMatch.Groups[1].Value);
         if (nameMatch is { Success: true }) {
             if (nameMatch.Groups.Count == 3) {
-                containerRegistry = nameMatch.Groups[1].Value;
+                containerRegistry = nameMatch.Groups[1].Success? nameMatch.Groups[1].Value : DefaultRegistry;
                 containerName = nameMatch.Groups[2].Value;
             } else {
                 containerRegistry = DefaultRegistry;

--- a/Microsoft.NET.Build.Containers/ContainerHelpers.cs
+++ b/Microsoft.NET.Build.Containers/ContainerHelpers.cs
@@ -174,8 +174,8 @@ public static class Patterns
     /// domain and trailing components.
     /// </summary>
     private static readonly string anchoredName = anchored(
-        optional(capture(domain), literal("/")),
-        capture(nameComponent, optional(repeated(literal("/"), nameComponent)))
+        optional(capture(domain), literal("/")), // mcr.microsoft.com
+        capture(nameComponent, optional(repeated(literal("/"), nameComponent))) // (dotnet)(/runtime)(/sdk-container-demo)
     );
 
     /// <summary>

--- a/Microsoft.NET.Build.Containers/ContainerHelpers.cs
+++ b/Microsoft.NET.Build.Containers/ContainerHelpers.cs
@@ -6,7 +6,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using static Patterns;
 
-static class Patterns {
+public static class Patterns {
     
     private static readonly string alphaNumeric = @"[a-z0-9]+";
     private static readonly string separator = @"(?:[._]|__|[-]*)";
@@ -31,6 +31,7 @@ static class Patterns {
     );
 
     public static readonly Regex DomainRegexp = new (domain);
+    public static readonly Regex AnchoredDomainRegexp = new(anchored(domain));
 
     private static readonly string tag = @"[\w][\w.-]{0,127}";
 
@@ -126,7 +127,7 @@ public static class ContainerHelpers
     /// </summary>
     /// <param name="registryName"></param>
     /// <returns></returns>
-    public static bool IsValidRegistry(string registryName) => NameRegexp.IsMatch(registryName);
+    public static bool IsValidRegistry(string registryName) => AnchoredDomainRegexp.IsMatch(registryName);
 
     /// <summary>
     /// Ensures the given image name is valid.

--- a/Microsoft.NET.Build.Containers/CreateNewImage.cs
+++ b/Microsoft.NET.Build.Containers/CreateNewImage.cs
@@ -168,8 +168,7 @@ public class CreateNewImage : Microsoft.Build.Utilities.Task
         if (IsDockerPull) {
             throw new ArgumentException("Don't know how to pull images from local daemons at the moment");
         } else {
-            var prefix = BaseRegistry.StartsWith("localhost") ? "http" : "https";
-            var reg = new Registry(new Uri($"{prefix}://{BaseRegistry}"));
+            var reg = new Registry(ContainerHelpers.TryExpandRegistryToUri(BaseRegistry));
             return reg.GetImageManifest(BaseImageName, BaseImageTag).Result;
         }
     }
@@ -208,7 +207,7 @@ public class CreateNewImage : Microsoft.Build.Utilities.Task
         }
 
         var isDockerPush = OutputRegistry.StartsWith("docker://");
-        Registry? outputReg = isDockerPush ? null : new Registry(new Uri(OutputRegistry));
+        Registry? outputReg = isDockerPush ? null : new Registry(ContainerHelpers.TryExpandRegistryToUri(OutputRegistry));
         foreach (var tag in ImageTags)
         {
             if (isDockerPush)

--- a/Microsoft.NET.Build.Containers/CreateNewImage.cs
+++ b/Microsoft.NET.Build.Containers/CreateNewImage.cs
@@ -166,7 +166,7 @@ public class CreateNewImage : Microsoft.Build.Utilities.Task
 
     private Image GetBaseImage() {
         if (IsDockerPull) {
-            throw new ArgumentException("Don't know how to pull images from local daemons at the moment");
+            return LocalDocker.Pull(BaseImageName, BaseImageTag).Result;
         } else {
             var reg = new Registry(ContainerHelpers.TryExpandRegistryToUri(BaseRegistry));
             return reg.GetImageManifest(BaseImageName, BaseImageTag).Result;

--- a/Microsoft.NET.Build.Containers/CreateNewImage.cs
+++ b/Microsoft.NET.Build.Containers/CreateNewImage.cs
@@ -94,7 +94,7 @@ public class CreateNewImage : Microsoft.Build.Utilities.Task
     /// </summary>
     public ITaskItem[] Labels { get; set; }
 
-    private bool IsDockerPush { get => OutputRegistry == "docker://"; }
+    private bool IsDockerPush { get => OutputRegistry == ContainerHelpers.DefaultRegistry; }
 
     private bool IsDockerPull { get => BaseRegistry.StartsWith(ContainerHelpers.DefaultRegistry); }
 
@@ -206,11 +206,10 @@ public class CreateNewImage : Microsoft.Build.Utilities.Task
             return false;
         }
 
-        var isDockerPush = OutputRegistry.StartsWith("docker://");
-        Registry? outputReg = isDockerPush ? null : new Registry(ContainerHelpers.TryExpandRegistryToUri(OutputRegistry));
+        Registry? outputReg = IsDockerPush ? null : new Registry(ContainerHelpers.TryExpandRegistryToUri(OutputRegistry));
         foreach (var tag in ImageTags)
         {
-            if (isDockerPush)
+            if (IsDockerPush)
             {
                 try
                 {

--- a/Microsoft.NET.Build.Containers/CreateNewImage.cs
+++ b/Microsoft.NET.Build.Containers/CreateNewImage.cs
@@ -166,7 +166,7 @@ public class CreateNewImage : Microsoft.Build.Utilities.Task
 
     private Image GetBaseImage() {
         if (IsDockerPull) {
-            return LocalDocker.Pull(BaseImageName, BaseImageTag).Result;
+            return LocalDocker.Pull(BaseImageName, BaseImageTag);
         } else {
             var reg = new Registry(ContainerHelpers.TryExpandRegistryToUri(BaseRegistry));
             return reg.GetImageManifest(BaseImageName, BaseImageTag).Result;

--- a/Microsoft.NET.Build.Containers/ParseContainerProperties.cs
+++ b/Microsoft.NET.Build.Containers/ParseContainerProperties.cs
@@ -143,7 +143,8 @@ public class ParseContainerProperties : Microsoft.Build.Utilities.Task
         if (!ContainerHelpers.TryParseFullyQualifiedContainerName(FullyQualifiedBaseImageName,
                                                                   out string? outputReg,
                                                                   out string? outputImage,
-                                                                  out string? outputTag))
+                                                                  out string? outputTag,
+                                                                  out string? _outputDigest))
         {
             Log.LogError($"Could not parse {nameof(FullyQualifiedBaseImageName)}: {{0}}", FullyQualifiedBaseImageName);
             return !Log.HasLoggedErrors;

--- a/Test.Microsoft.NET.Build.Containers.Filesystem/CreateNewImageTests.cs
+++ b/Test.Microsoft.NET.Build.Containers.Filesystem/CreateNewImageTests.cs
@@ -42,11 +42,11 @@ public class CreateNewImageTests
         Assert.AreEqual(0, dotnetPublish.ExitCode);
 
         CreateNewImage task = new CreateNewImage();
-        task.BaseRegistry = "https://mcr.microsoft.com";
+        task.BaseRegistry = "mcr.microsoft.com";
         task.BaseImageName = "dotnet/runtime";
         task.BaseImageTag = "6.0";
 
-        task.OutputRegistry = "http://localhost:5010";
+        task.OutputRegistry = "localhost:5010";
         task.PublishDirectory = Path.Combine(newProjectDir.FullName, "bin", "release", "net7.0");
         task.ImageName = "dotnet/testimage";
         task.WorkingDirectory = "app/";
@@ -90,13 +90,13 @@ public class CreateNewImageTests
         Assert.AreEqual(0, dotnetPublish.ExitCode);
 
         ParseContainerProperties pcp = new ParseContainerProperties();
-        pcp.FullyQualifiedBaseImageName = "https://mcr.microsoft.com/dotnet/runtime:6.0";
-        pcp.ContainerRegistry = "http://localhost:5010";
+        pcp.FullyQualifiedBaseImageName = "mcr.microsoft.com/dotnet/runtime:6.0";
+        pcp.ContainerRegistry = "localhost:5010";
         pcp.ContainerImageName = "dotnet/testimage";
         pcp.ContainerImageTags = new [] {"5.0", "latest"};
 
         Assert.IsTrue(pcp.Execute());
-        Assert.AreEqual("https://mcr.microsoft.com", pcp.ParsedContainerRegistry);
+        Assert.AreEqual("mcr.microsoft.com", pcp.ParsedContainerRegistry);
         Assert.AreEqual("dotnet/runtime", pcp.ParsedContainerImage);
         Assert.AreEqual("6.0", pcp.ParsedContainerTag);
 
@@ -108,7 +108,7 @@ public class CreateNewImageTests
         cni.BaseImageName = pcp.ParsedContainerImage;
         cni.BaseImageTag = pcp.ParsedContainerTag;
         cni.ImageName = pcp.NewContainerImageName;
-        cni.OutputRegistry = "http://localhost:5010";
+        cni.OutputRegistry = "localhost:5010";
         cni.PublishDirectory = Path.Combine(newProjectDir.FullName, "bin", "release", "net7.0");
         cni.WorkingDirectory = "app/";
         cni.Entrypoint = new TaskItem[] { new("ParseContainerProperties_EndToEnd") };

--- a/Test.Microsoft.NET.Build.Containers.Filesystem/DockerRegistryManager.cs
+++ b/Test.Microsoft.NET.Build.Containers.Filesystem/DockerRegistryManager.cs
@@ -9,7 +9,7 @@ public class DockerRegistryManager
     public const string BaseImageSource = "mcr.microsoft.com/";
     public const string BaseImageTag = "6.0";
     public const string LocalRegistry = "localhost:5010";
-    public const string FullyQualifiedBaseImageDefault = $"https://{BaseImageSource}{BaseImage}:{BaseImageTag}";
+    public const string FullyQualifiedBaseImageDefault = $"{BaseImageSource}{BaseImage}:{BaseImageTag}";
     private static string s_registryContainerId;
 
     private static void Exec(string command, string args) {

--- a/Test.Microsoft.NET.Build.Containers.Filesystem/EndToEnd.cs
+++ b/Test.Microsoft.NET.Build.Containers.Filesystem/EndToEnd.cs
@@ -29,7 +29,7 @@ public class EndToEnd
 
         // Build the image
 
-        Registry registry = new Registry(new Uri($"http://{DockerRegistryManager.LocalRegistry}"));
+        Registry registry = new Registry(ContainerHelpers.TryExpandRegistryToUri(DockerRegistryManager.LocalRegistry));
 
         Image x = await registry.GetImageManifest(DockerRegistryManager.BaseImage, DockerRegistryManager.BaseImageTag);
 
@@ -67,7 +67,7 @@ public class EndToEnd
 
         // Build the image
 
-        Registry registry = new Registry(new Uri($"http://{DockerRegistryManager.LocalRegistry}"));
+        Registry registry = new Registry(ContainerHelpers.TryExpandRegistryToUri(DockerRegistryManager.LocalRegistry));
 
         Image x = await registry.GetImageManifest(DockerRegistryManager.BaseImage, DockerRegistryManager.BaseImageTag);
 

--- a/Test.Microsoft.NET.Build.Containers.Filesystem/EndToEnd.cs
+++ b/Test.Microsoft.NET.Build.Containers.Filesystem/EndToEnd.cs
@@ -214,7 +214,8 @@ public class EndToEnd
         await pull.WaitForExitAsync();
         Assert.AreEqual(0, pull.ExitCode);
 
-        ProcessStartInfo runInfo = new("docker", $"run --rm --publish 5017:80 --detach {DockerRegistryManager.LocalRegistry}/{imageName}:{imageTag}")
+        var containerName = "test-container-1";
+        ProcessStartInfo runInfo = new("docker", $"run --rm --name {containerName} --publish 5017:80 --detach {DockerRegistryManager.LocalRegistry}/{imageName}:{imageTag}")
         {
             RedirectStandardOutput = true,
             RedirectStandardError = true,
@@ -250,6 +251,15 @@ public class EndToEnd
         }
 
         Assert.AreEqual(true, everSucceeded);
+
+        ProcessStartInfo logsPsi = new("docker", $"logs {appContainerId}") {
+            RedirectStandardOutput = true
+        };
+
+        Process logs = Process.Start(logsPsi);
+        Assert.IsNotNull(logs);
+        await logs.WaitForExitAsync();
+        Console.WriteLine(logs.StandardOutput.ReadToEnd());
 
         ProcessStartInfo stopPsi = new("docker", $"stop {appContainerId}")
         {

--- a/Test.Microsoft.NET.Build.Containers.Filesystem/EndToEnd.cs
+++ b/Test.Microsoft.NET.Build.Containers.Filesystem/EndToEnd.cs
@@ -140,6 +140,8 @@ public class EndToEnd
 
         newProjectDir.Create();
         privateNuGetAssets.Create();
+        var repoGlobalJson = Path.Combine("..", "..", "..", "..", "global.json");
+        File.Copy(repoGlobalJson, Path.Combine(newProjectDir.FullName, "global.json"));
 
         // 🤢
         DirectoryInfo nupkgPath = new DirectoryInfo(Assembly.GetAssembly(this.GetType()).Location).Parent.Parent.Parent.Parent;
@@ -190,14 +192,14 @@ public class EndToEnd
         Process dotnetPackageAdd = Process.Start(info);
         Assert.IsNotNull(dotnetPackageAdd);
         await dotnetPackageAdd.WaitForExitAsync();
-        Assert.AreEqual(0, dotnetPackageAdd.ExitCode);
+        Assert.AreEqual(0, dotnetPackageAdd.ExitCode, dotnetPackageAdd.StandardOutput.ReadToEnd());
 
         string imageName = NewImageName();
         string imageTag = "1.0";
 
         info.Arguments = $"publish /p:publishprofile=DefaultContainer /p:runtimeidentifier=linux-x64 /bl" +
                           $" /p:ContainerBaseImage={DockerRegistryManager.FullyQualifiedBaseImageDefault}" +
-                          $" /p:ContainerRegistry=http://{DockerRegistryManager.LocalRegistry}" +
+                          $" /p:ContainerRegistry={DockerRegistryManager.LocalRegistry}" +
                           $" /p:ContainerImageName={imageName}" +
                           $" /p:Version={imageTag}";
 
@@ -234,7 +236,7 @@ public class EndToEnd
         {
             try
             {
-                var response = await client.GetAsync("http://localhost:5017/weatherforecast");
+                var response = await client.GetAsync("localhost:5017/weatherforecast");
 
                 if (response.IsSuccessStatusCode)
                 {

--- a/Test.Microsoft.NET.Build.Containers.Filesystem/EndToEnd.cs
+++ b/Test.Microsoft.NET.Build.Containers.Filesystem/EndToEnd.cs
@@ -237,7 +237,7 @@ public class EndToEnd
         {
             try
             {
-                var response = await client.GetAsync("localhost:5017/weatherforecast");
+                var response = await client.GetAsync("http://localhost:5017/weatherforecast");
 
                 if (response.IsSuccessStatusCode)
                 {

--- a/Test.Microsoft.NET.Build.Containers.Filesystem/EndToEnd.cs
+++ b/Test.Microsoft.NET.Build.Containers.Filesystem/EndToEnd.cs
@@ -250,8 +250,6 @@ public class EndToEnd
             await Task.Delay(TimeSpan.FromSeconds(1));
         }
 
-        Assert.AreEqual(true, everSucceeded);
-
         ProcessStartInfo logsPsi = new("docker", $"logs {appContainerId}") {
             RedirectStandardOutput = true
         };
@@ -259,7 +257,9 @@ public class EndToEnd
         Process logs = Process.Start(logsPsi);
         Assert.IsNotNull(logs);
         await logs.WaitForExitAsync();
-        Console.WriteLine(logs.StandardOutput.ReadToEnd());
+
+        Assert.AreEqual(true, everSucceeded, logs.StandardOutput.ReadToEnd());
+
 
         ProcessStartInfo stopPsi = new("docker", $"stop {appContainerId}")
         {

--- a/Test.Microsoft.NET.Build.Containers.Filesystem/LocalDockerTests.cs
+++ b/Test.Microsoft.NET.Build.Containers.Filesystem/LocalDockerTests.cs
@@ -1,0 +1,15 @@
+using Microsoft.NET.Build.Containers;
+using System.IO.Compression;
+using System.Security.Cryptography;
+
+namespace Test.Microsoft.NET.Build.Containers.Filesystem;
+
+[TestClass]
+public class LocalDockerTests
+{
+    [TestMethod]
+    public void CanPullImageFromLocalDocker()
+    {
+        LocalDocker.Pull("mcr.microsoft.com/dotnet/runtime", "6.0");
+    }
+}

--- a/Test.Microsoft.NET.Build.Containers.Filesystem/ParseContainerPropertiesTests.cs
+++ b/Test.Microsoft.NET.Build.Containers.Filesystem/ParseContainerPropertiesTests.cs
@@ -12,13 +12,13 @@ namespace Test.Microsoft.NET.Build.Containers.Tasks
         public void Baseline()
         {
             ParseContainerProperties task = new ParseContainerProperties();
-            task.FullyQualifiedBaseImageName = "https://mcr.microsoft.com/dotnet/runtime:6.0";
-            task.ContainerRegistry = "http://localhost:5010";
+            task.FullyQualifiedBaseImageName = "mcr.microsoft.com/dotnet/runtime:6.0";
+            task.ContainerRegistry = "localhost:5010";
             task.ContainerImageName = "dotnet/testimage";
             task.ContainerImageTags = new[] { "5.0" };
 
             Assert.IsTrue(task.Execute());
-            Assert.AreEqual("https://mcr.microsoft.com", task.ParsedContainerRegistry);
+            Assert.AreEqual("mcr.microsoft.com", task.ParsedContainerRegistry);
             Assert.AreEqual("dotnet/runtime", task.ParsedContainerImage);
             Assert.AreEqual("6.0", task.ParsedContainerTag);
 
@@ -31,16 +31,16 @@ namespace Test.Microsoft.NET.Build.Containers.Tasks
         {
             ParseContainerProperties task = new ParseContainerProperties();
             task.FullyQualifiedBaseImageName = "mcr.microsoft.com/dotnet/runtime:6.0";
-            task.ContainerRegistry = "http://localhost:5010";
+            task.ContainerRegistry = "localhost:5010";
             task.ContainerImageName = "dotnet/testimage";
             task.ContainerImageTags = new[] { "5.0" };
 
             Assert.IsTrue(task.Execute());
-            Assert.AreEqual("https://mcr.microsoft.com", task.ParsedContainerRegistry);
+            Assert.AreEqual("mcr.microsoft.com", task.ParsedContainerRegistry);
             Assert.AreEqual("dotnet/runtime", task.ParsedContainerImage);
             Assert.AreEqual("6.0", task.ParsedContainerTag);
 
-            Assert.AreEqual("http://localhost:5010", task.NewContainerRegistry);
+            Assert.AreEqual("localhost:5010", task.NewContainerRegistry);
             Assert.AreEqual("dotnet/testimage", task.NewContainerImageName);
             new[] { "5.0" }.SequenceEqual(task.NewContainerTags);
         }
@@ -55,11 +55,11 @@ namespace Test.Microsoft.NET.Build.Containers.Tasks
             task.ContainerImageTags = new[] { "5.0" };
 
             Assert.IsTrue(task.Execute());
-            Assert.AreEqual("https://mcr.microsoft.com", task.ParsedContainerRegistry);
+            Assert.AreEqual("mcr.microsoft.com", task.ParsedContainerRegistry);
             Assert.AreEqual("dotnet/runtime", task.ParsedContainerImage);
             Assert.AreEqual("6.0", task.ParsedContainerTag);
 
-            Assert.AreEqual("https://localhost:5010", task.NewContainerRegistry);
+            Assert.AreEqual("localhost:5010", task.NewContainerRegistry);
             Assert.AreEqual("dotnet/testimage", task.NewContainerImageName);
             new[] { "5.0" }.SequenceEqual(task.NewContainerTags);
         }
@@ -69,14 +69,14 @@ namespace Test.Microsoft.NET.Build.Containers.Tasks
         {
             ParseContainerProperties task = new ParseContainerProperties();
             task.FullyQualifiedBaseImageName = "mcr microsoft com/dotnet runtime:6 0";
-            task.ContainerRegistry = "http://localhost:5010";
+            task.ContainerRegistry = "localhost:5010";
 
             // Spaces in the "new" container info don't pass the regex.
             task.ContainerImageName = "dotnet/testimage";
             task.ContainerImageTags = new[] { "5.0" };
 
             Assert.IsTrue(task.Execute());
-            Assert.AreEqual("https://mcr-microsoft-com", task.ParsedContainerRegistry);
+            Assert.AreEqual("mcr-microsoft-com", task.ParsedContainerRegistry);
             Assert.AreEqual("dotnet-runtime", task.ParsedContainerImage);
             Assert.AreEqual("6-0", task.ParsedContainerTag);
 
@@ -90,7 +90,7 @@ namespace Test.Microsoft.NET.Build.Containers.Tasks
         {
             ParseContainerProperties task = new ParseContainerProperties();
             task.FullyQualifiedBaseImageName = "mcr.microsoft.com/dotnet/runtime:6 0";
-            task.ContainerRegistry = "http://localhost:5010";
+            task.ContainerRegistry = "localhost:5010";
 
             // Spaces in the "new" container info don't pass the regex.
             task.ContainerImageName = "dotnet testimage";
@@ -106,7 +106,7 @@ namespace Test.Microsoft.NET.Build.Containers.Tasks
         {
             ParseContainerProperties task = new ParseContainerProperties();
             task.FullyQualifiedBaseImageName = "mcr.microsoft.com/dotnet/runtime:6 0";
-            task.ContainerRegistry = "http://localhost:5010";
+            task.ContainerRegistry = "localhost:5010";
             // Spaces in the "new" container info don't pass the regex.
             task.ContainerImageName = "dotnet/testimage";
             task.ContainerImageTags = new[] { "5.0" };
@@ -121,7 +121,7 @@ namespace Test.Microsoft.NET.Build.Containers.Tasks
         {
             ParseContainerProperties task = new ParseContainerProperties();
             task.FullyQualifiedBaseImageName = "mcr.microsoft.com/dotnet/runtime:6 0";
-            task.ContainerRegistry = "http://localhost:5010";
+            task.ContainerRegistry = "localhost:5010";
             // Spaces in the "new" container info don't pass the regex.
             task.ContainerImageName = "dotnet/testimage";
             task.ContainerImageTag = "a.b";

--- a/Test.Microsoft.NET.Build.Containers.Filesystem/RegistryTests.cs
+++ b/Test.Microsoft.NET.Build.Containers.Filesystem/RegistryTests.cs
@@ -13,7 +13,7 @@ public class RegistryTests
     [TestMethod]
     public async Task GetFromRegistry()
     {
-        Registry registry = new Registry(new Uri($"http://{DockerRegistryManager.LocalRegistry}"));
+        Registry registry = new Registry(ContainerHelpers.TryExpandRegistryToUri(DockerRegistryManager.LocalRegistry));
 
         Image downloadedImage = await registry.GetImageManifest(DockerRegistryManager.BaseImage, DockerRegistryManager.BaseImageTag);
 

--- a/Test.Microsoft.NET.Build.Containers/ContainerHelpersTests.cs
+++ b/Test.Microsoft.NET.Build.Containers/ContainerHelpersTests.cs
@@ -8,34 +8,31 @@ public class ContainerHelpersTests
 {
     [TestMethod]
     // Valid Tests
-    [DataRow("https://mcr.microsoft.com", true)]
-    [DataRow("https://mcr.microsoft.com/", true)]
-    [DataRow("http://mcr.microsoft.com:5001", true)] // Registries can have ports
-    [DataRow("docker://mcr.microsoft.com:5001", true)] // docker:// is considered valid
+    [DataRow("mcr.microsoft.com", true)]
+    [DataRow("mcr.microsoft.com/", true)]
+    [DataRow("mcr.microsoft.com:5001", true)] // Registries can have ports
+    [DataRow("docker://", true)] // docker:// is considered valid
 
     // // Invalid tests
-    [DataRow("docker://mcr.microsoft.com:xyz/dotnet/runtime:6.0", false)] // invalid port
-    [DataRow("httpz://mcr.microsoft.com", false)] // invalid scheme
-    [DataRow("https://mcr.mi-=crosoft.com", false)] // invalid url
-    [DataRow("mcr.microsoft.com/", false)] // Missing scheme
+    [DataRow("mcr.mi-=crosoft.com", false)] // invalid url
     public void IsValidRegistry(string registry, bool expectedReturn)
     {
         Assert.AreEqual(expectedReturn, ContainerHelpers.IsValidRegistry(registry));
     }
 
     [TestMethod]
-    [DataRow("https://mcr.microsoft.com/dotnet/runtime:6.0", true, "https://mcr.microsoft.com", "dotnet/runtime", "6.0")]
-    [DataRow("https://mcr.microsoft.com/dotnet/runtime", true, "https://mcr.microsoft.com", "dotnet/runtime", "")]
-    [DataRow("docker://mcr.microsoft.com/dotnet/runtime", true, "docker://mcr.microsoft.com", "dotnet/runtime", "")]
-    [DataRow("https://mcr.microsoft.com/", false, null, null, null)] // no image = nothing resolves
+    [DataRow("mcr.microsoft.com/dotnet/runtime:6.0", true, "mcr.microsoft.com", "dotnet/runtime", "6.0")]
+    [DataRow("mcr.microsoft.com/dotnet/runtime", true, "mcr.microsoft.com", "dotnet/runtime", "")]
+    [DataRow("mcr.microsoft.com/dotnet/runtime", true, "mcr.microsoft.com", "dotnet/runtime", "")]
+    [DataRow("mcr.microsoft.com/", false, null, null, null)] // no image = nothing resolves
     // Ports tag along
-    [DataRow("docker://mcr.microsoft.com:54/dotnet/runtime", true, "docker://mcr.microsoft.com:54", "dotnet/runtime", "")]
-    // Unless they're invalid
-    [DataRow("docker://mcr.microsoft.com:0/dotnet/runtime", true, "docker://mcr.microsoft.com", "dotnet/runtime", "")]
-    // Strip the ':' in an unspecified port
-    [DataRow("docker://mcr.microsoft.com:/dotnet/runtime", true, "docker://mcr.microsoft.com", "dotnet/runtime", "")]
+    [DataRow("mcr.microsoft.com:54/dotnet/runtime", true, "mcr.microsoft.com:54", "dotnet/runtime", "")]
+    // Even if nonsensical
+    [DataRow("mcr.microsoft.com:0/dotnet/runtime", true, "mcr.microsoft.com:0", "dotnet/runtime", "")]
+    // We don't allow hosts with missing ports when a port is anticipated
+    [DataRow("mcr.microsoft.com:/dotnet/runtime", false, null, null, null)]
     // no image = nothing resolves
-    [DataRow("https://mcr.microsoft.com/", false, null, null, null)]
+    [DataRow("mcr.microsoft.com/", false, null, null, null)]
     public void TryParseFullyQualifiedContainerName(string fullyQualifiedName, bool expectedReturn, string expectedRegistry, string expectedImage, string expectedTag)
     {
         Assert.AreEqual(expectedReturn, ContainerHelpers.TryParseFullyQualifiedContainerName(fullyQualifiedName, out string? containerReg, out string? containerName, out string? containerTag));

--- a/Test.Microsoft.NET.Build.Containers/ContainerHelpersTests.cs
+++ b/Test.Microsoft.NET.Build.Containers/ContainerHelpersTests.cs
@@ -9,14 +9,15 @@ public class ContainerHelpersTests
     [TestMethod]
     // Valid Tests
     [DataRow("mcr.microsoft.com", true)]
-    [DataRow("mcr.microsoft.com/", true)]
     [DataRow("mcr.microsoft.com:5001", true)] // Registries can have ports
-    [DataRow("docker://", true)] // docker:// is considered valid
+    [DataRow("docker.io", true)] // default docker registry is considered valid
 
     // // Invalid tests
     [DataRow("mcr.mi-=crosoft.com", false)] // invalid url
+    [DataRow("mcr.microsoft.com/", false)] // invalid url
     public void IsValidRegistry(string registry, bool expectedReturn)
     {
+        Console.WriteLine($"Domain pattern is '{Patterns.AnchoredDomainRegexp.ToString()}'");
         Assert.AreEqual(expectedReturn, ContainerHelpers.IsValidRegistry(registry));
     }
 

--- a/Test.Microsoft.NET.Build.Containers/ContainerHelpersTests.cs
+++ b/Test.Microsoft.NET.Build.Containers/ContainerHelpersTests.cs
@@ -34,6 +34,7 @@ public class ContainerHelpersTests
     [DataRow("mcr.microsoft.com:/dotnet/runtime", false, null, null, null)]
     // no image = nothing resolves
     [DataRow("mcr.microsoft.com/", false, null, null, null)]
+    [DataRow("ubuntu:jammy", true, ContainerHelpers.DefaultRegistry, "ubuntu", "jammy")]
     public void TryParseFullyQualifiedContainerName(string fullyQualifiedName, bool expectedReturn, string expectedRegistry, string expectedImage, string expectedTag)
     {
         Assert.AreEqual(expectedReturn, ContainerHelpers.TryParseFullyQualifiedContainerName(fullyQualifiedName, out string? containerReg, out string? containerName, out string? containerTag));

--- a/Test.Microsoft.NET.Build.Containers/ContainerHelpersTests.cs
+++ b/Test.Microsoft.NET.Build.Containers/ContainerHelpersTests.cs
@@ -23,13 +23,13 @@ public class ContainerHelpersTests
 
     [TestMethod]
     [DataRow("mcr.microsoft.com/dotnet/runtime:6.0", true, "mcr.microsoft.com", "dotnet/runtime", "6.0")]
-    [DataRow("mcr.microsoft.com/dotnet/runtime", true, "mcr.microsoft.com", "dotnet/runtime", "")]
-    [DataRow("mcr.microsoft.com/dotnet/runtime", true, "mcr.microsoft.com", "dotnet/runtime", "")]
+    [DataRow("mcr.microsoft.com/dotnet/runtime", true, "mcr.microsoft.com", "dotnet/runtime", null)]
+    [DataRow("mcr.microsoft.com/dotnet/runtime", true, "mcr.microsoft.com", "dotnet/runtime", null)]
     [DataRow("mcr.microsoft.com/", false, null, null, null)] // no image = nothing resolves
     // Ports tag along
-    [DataRow("mcr.microsoft.com:54/dotnet/runtime", true, "mcr.microsoft.com:54", "dotnet/runtime", "")]
+    [DataRow("mcr.microsoft.com:54/dotnet/runtime", true, "mcr.microsoft.com:54", "dotnet/runtime", null)]
     // Even if nonsensical
-    [DataRow("mcr.microsoft.com:0/dotnet/runtime", true, "mcr.microsoft.com:0", "dotnet/runtime", "")]
+    [DataRow("mcr.microsoft.com:0/dotnet/runtime", true, "mcr.microsoft.com:0", "dotnet/runtime", null)]
     // We don't allow hosts with missing ports when a port is anticipated
     [DataRow("mcr.microsoft.com:/dotnet/runtime", false, null, null, null)]
     // no image = nothing resolves
@@ -37,7 +37,7 @@ public class ContainerHelpersTests
     [DataRow("ubuntu:jammy", true, ContainerHelpers.DefaultRegistry, "ubuntu", "jammy")]
     public void TryParseFullyQualifiedContainerName(string fullyQualifiedName, bool expectedReturn, string expectedRegistry, string expectedImage, string expectedTag)
     {
-        Assert.AreEqual(expectedReturn, ContainerHelpers.TryParseFullyQualifiedContainerName(fullyQualifiedName, out string? containerReg, out string? containerName, out string? containerTag));
+        Assert.AreEqual(expectedReturn, ContainerHelpers.TryParseFullyQualifiedContainerName(fullyQualifiedName, out string? containerReg, out string? containerName, out string? containerTag, out string? containerDigest));
         Assert.AreEqual(expectedRegistry, containerReg);
         Assert.AreEqual(expectedImage, containerName);
         Assert.AreEqual(expectedTag, containerTag);

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "version": "7.0.100-rc.1.22431.12",
     "allowPrerelease": true,
-    "rollForward": "latestMajor"
+    "rollForward": "latestMajor",
+    "version": "7.0.100-rc.1.22431.12"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
+    "version": "7.0.100-rc.1.22431.12",
     "allowPrerelease": true,
-    "rollForward": "latestMajor",
-    "version": "7.0.100-rc.1.22431.12"
+    "rollForward": "latestMajor"
   }
 }

--- a/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -39,7 +39,7 @@
         <!-- Container Defaults -->
         <PropertyGroup>
             <ContainerBaseImage Condition="'$(ContainerBaseImage)' == ''">$(_ContainerBaseRegistry)/$(_ContainerBaseImageName):$(_ContainerBaseImageTag)</ContainerBaseImage>
-            <ContainerRegistry Condition="'$(ContainerRegistry)' == ''">docker://</ContainerRegistry>
+            <ContainerRegistry Condition="'$(ContainerRegistry)' == ''">docker.io</ContainerRegistry>
             <!-- Note: spaces will be replaced with '-' in ContainerImageName and ContainerImageTag -->
             <ContainerImageName Condition="'$(ContainerImageName)' == ''">$(AssemblyName)</ContainerImageName>
             <!-- Only default a tag name if no tag names at all are provided -->

--- a/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -22,7 +22,7 @@
 
         <!-- Compute private defaults -->
         <PropertyGroup Condition="$(ContainerBaseImage) == ''">
-            <_ContainerBaseRegistry>https://mcr.microsoft.com</_ContainerBaseRegistry>
+            <_ContainerBaseRegistry>mcr.microsoft.com</_ContainerBaseRegistry>
             <_ContainerBaseImageName Condition="'$(_IsSelfContained)' == 'true'">dotnet/runtime-deps</_ContainerBaseImageName>
             <_ContainerBaseImageName Condition="'$(_ContainerBaseImageName)' == '' and '$(_IsAspNet)' == 'true'">dotnet/aspnet</_ContainerBaseImageName>
             <_ContainerBaseImageName Condition="'$(_ContainerBaseImageName)' == ''">dotnet/runtime</_ContainerBaseImageName>


### PR DESCRIPTION
Part 2 of #195.

A few parts of the codebase assumed that image manifests and blobs would be coming from a registry, but in the case of a reference to an image in a local daemon (e.g. `ubuntu:jammy` with no defined registry component), that is not the case.

In order to support this workflow, we need a way to:
* identify these locally-sourced images (implemented in #196)
* use the `docker save` command to create TARs of locally-sourced images
* import the contents of that TAR into the content store (where it can be universally addressed)
* locate and parse the manifest and config in the TAR to make an Image

That is all done!

I want to add some end-to-end tests because I think we may need a branch-point at the part where we fetch the image layer blobs, but I think we're a good 70% of the way there at this point.