### PR TITLE
Allow OutputRegistry to be set to null

### DIFF
--- a/Microsoft.NET.Build.Containers/CreateNewImage.cs
+++ b/Microsoft.NET.Build.Containers/CreateNewImage.cs
@@ -44,7 +44,6 @@ public class CreateNewImage : Microsoft.Build.Utilities.Task
     /// <summary>
     /// The registry to push to.
     /// </summary>
-    [Required]
     public string OutputRegistry { get; set; }
 
     /// <summary>

--- a/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -39,7 +39,10 @@
         <!-- Container Defaults -->
         <PropertyGroup>
             <ContainerBaseImage Condition="'$(ContainerBaseImage)' == ''">$(_ContainerBaseRegistry)/$(_ContainerBaseImageName):$(_ContainerBaseImageTag)</ContainerBaseImage>
-            <!-- ContainerRegistry is a thing, and it defaults to empty to signal no registry - i.e. a local daemon image. -->
+
+            <!-- An empty ContainerRegistry implies pushing to the local daemon, putting this here for documentation purposes -->
+            <!-- <ContainerRegistry></ContainerRegistry> -->
+
             <!-- Note: spaces will be replaced with '-' in ContainerImageName and ContainerImageTag -->
             <ContainerImageName Condition="'$(ContainerImageName)' == ''">$(AssemblyName)</ContainerImageName>
             <!-- Only default a tag name if no tag names at all are provided -->


### PR DESCRIPTION
In https://github.com/dotnet/sdk-container-builds/pull/196 we started using a null value of OutputRegistry to signal that the push was to a local docker daemon. As a result, we need the OutputRegistry property to no longer be Required.