### PR TITLE
Add more verbose logging during the build

### DIFF
--- a/Microsoft.NET.Build.Containers/ContainerBuilder.cs
+++ b/Microsoft.NET.Build.Containers/ContainerBuilder.cs
@@ -72,7 +72,7 @@ public static class ContainerBuilder
             {
                 try
                 {
-                    outputReg?.Push(img, imageName, tag, imageName).Wait();
+                    outputReg?.Push(img, imageName, tag, imageName, (message) => Console.WriteLine($"Containerize: {message}")).Wait();
                     Console.WriteLine($"Containerize: Pushed container '{imageName}:{tag}' to registry '{outputRegistry}'");
                 }
                 catch (Exception e)

--- a/Microsoft.NET.Build.Containers/ParseContainerProperties.cs
+++ b/Microsoft.NET.Build.Containers/ParseContainerProperties.cs
@@ -165,7 +165,7 @@ public class ParseContainerProperties : Microsoft.Build.Utilities.Task
         {
             if (!ContainerHelpers.NormalizeImageName(ContainerImageName, out string? normalizedImageName))
             {
-                Log.LogMessage(MessageImportance.High, $"{nameof(ContainerImageName)}:'{ContainerImageName}' was not a valid container image name, it was normalized to {normalizedImageName}");
+                Log.LogMessage(MessageImportance.High, $"'{ContainerImageName}' was not a valid container image name, it was normalized to {normalizedImageName}");
                 NewContainerImageName = normalizedImageName ?? "";
             }
             else

--- a/Test.Microsoft.NET.Build.Containers.Filesystem/EndToEnd.cs
+++ b/Test.Microsoft.NET.Build.Containers.Filesystem/EndToEnd.cs
@@ -41,7 +41,7 @@ public class EndToEnd
 
         // Push the image back to the local registry
 
-        await registry.Push(x, NewImageName(), "latest", DockerRegistryManager.BaseImage);
+        await registry.Push(x, NewImageName(), "latest", DockerRegistryManager.BaseImage, Console.WriteLine);
 
         // pull it back locally
 


### PR DESCRIPTION
This logs a bit more during the build, especially around pushing layer and metadata blobs to the registry.

I mostly did this to help with debugging with @vijayrkn, so the levels will need to be tweaked as well.