### PR TITLE
Emit container manifest and config as msbuild items where possible

### DIFF
--- a/Microsoft.NET.Build.Containers/CreateNewImage.cs
+++ b/Microsoft.NET.Build.Containers/CreateNewImage.cs
@@ -98,6 +98,12 @@ public class CreateNewImage : Microsoft.Build.Utilities.Task
     /// </summary>
     public ITaskItem[] ContainerEnvironmentVariables { get; set; }
 
+    [Output]
+    public string GeneratedContainerManifest { get; set; }
+
+    [Output]
+    public string GeneratedContainerConfiguration { get; set; }
+
     private bool IsDockerPush { get => String.IsNullOrEmpty(OutputRegistry); }
 
     private bool IsDockerPull { get => String.IsNullOrEmpty(BaseRegistry); }
@@ -120,6 +126,8 @@ public class CreateNewImage : Microsoft.Build.Utilities.Task
         Labels = Array.Empty<ITaskItem>();
         ExposedPorts = Array.Empty<ITaskItem>();
         ContainerEnvironmentVariables = Array.Empty<ITaskItem>();
+        GeneratedContainerConfiguration = "";
+        GeneratedContainerManifest = "";
     }
 
     private void SetPorts(Image image, ITaskItem[] exposedPorts)
@@ -219,6 +227,10 @@ public class CreateNewImage : Microsoft.Build.Utilities.Task
         {
             return false;
         }
+
+        // at this point we're done with modifications and are just pushing the data other places
+        GeneratedContainerManifest = image.manifest.ToJsonString();
+        GeneratedContainerConfiguration = image.config.ToJsonString();
 
         Registry? outputReg = IsDockerPush ? null : new Registry(ContainerHelpers.TryExpandRegistryToUri(OutputRegistry));
         foreach (var tag in ImageTags)

--- a/Microsoft.NET.Build.Containers/CreateNewImageToolTask.cs
+++ b/Microsoft.NET.Build.Containers/CreateNewImageToolTask.cs
@@ -91,6 +91,12 @@ public class CreateNewImage : ToolTask
     /// Container environment variables to set.
     /// </summary>
     public ITaskItem[] ContainerEnvironmentVariables { get; set; }
+
+    [Output]
+    public string GeneratedContainerManifest { get; set; }
+
+    [Output]
+    public string GeneratedContainerConfiguration { get; set; }
  
     // Unused, ToolExe is set via targets and overrides this.
     protected override string ToolName => "dotnet";
@@ -125,9 +131,12 @@ public class CreateNewImage : ToolTask
         Labels = Array.Empty<ITaskItem>();
         ExposedPorts = Array.Empty<ITaskItem>();
         ContainerEnvironmentVariables = Array.Empty<ITaskItem>();
+        GeneratedContainerConfiguration = "";
+        GeneratedContainerManifest = "";
     }
 
     protected override string GenerateFullPathToTool() => Quote(Path.Combine(DotNetPath, ToolExe));
+
 
     protected override string GenerateCommandLineCommands()
     {

--- a/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -118,6 +118,9 @@
                         EntrypointArgs="@(ContainerEntrypointArgs)"
                         Labels="@(ContainerLabel)"
                         ExposedPorts="@(ContainerPort)"
-                        ContainerEnvironmentVariables="@(ContainerEnvironmentVariables)" />
+                        ContainerEnvironmentVariables="@(ContainerEnvironmentVariables)">
+            <Output TaskParameter="GeneratedContainerManifest" PropertyName="GeneratedContainerManifest" />
+            <Output TaskParameter="GeneratedContainerConfiguration" PropertyName="GeneratedContainerConfiguration" />
+        </CreateNewImage>
     </Target>
 </Project>


### PR DESCRIPTION
This should let us post-hoc investigate the manifests and configurations generated for the image.

I have no idea how to do similar for the tooltask, though - I guess we'd need to shim the `Execute()` member and look for special kinds of output from the executable?