### PR TITLE
More exhaustive future-facing checks for supported SDK versions

### DIFF
--- a/Test.Microsoft.NET.Build.Containers.Filesystem/TargetsTests.cs
+++ b/Test.Microsoft.NET.Build.Containers.Filesystem/TargetsTests.cs
@@ -46,7 +46,7 @@ public class TargetsTests
         props["_TargetFrameworkVersionWithoutV"] = "7.0";
         props["_NativeExecutableExtension"] = ".exe"; //TODO: windows/unix split here
         props["Version"] = "1.0.0"; // TODO: need to test non-compliant version strings here
-        props["NETCoreSdkVersion"] = "7.0.100"; // we manipulate this value during evaluation, so we need a sane default.
+        props["NETCoreSdkVersion"] = "7.0.100"; // we manipulate this value during evaluation, so we need a good default.
                                                 // tests that rely on checking this value can override it with bonusProps.
 
         // test setup parameters so that we can load the props/targets/tasks 

--- a/Test.Microsoft.NET.Build.Containers.Filesystem/TargetsTests.cs
+++ b/Test.Microsoft.NET.Build.Containers.Filesystem/TargetsTests.cs
@@ -37,7 +37,7 @@ public class TargetsTests
         if (CombinedTargetsLocation != null) File.Delete(CombinedTargetsLocation);
     }
 
-    private Project InitProject(Dictionary<string, string> bonusProps)
+    private (Project, IDisposable) InitProject(Dictionary<string, string> bonusProps, string logFileName = "log")
     {
         var props = new Dictionary<string, string>();
         // required parameters
@@ -46,6 +46,8 @@ public class TargetsTests
         props["_TargetFrameworkVersionWithoutV"] = "7.0";
         props["_NativeExecutableExtension"] = ".exe"; //TODO: windows/unix split here
         props["Version"] = "1.0.0"; // TODO: need to test non-compliant version strings here
+        props["NETCoreSdkVersion"] = "7.0.100"; // we manipulate this value during evaluation, so we need a sane default.
+                                                // tests that rely on checking this value can override it with bonusProps.
 
         // test setup parameters so that we can load the props/targets/tasks 
         props["CustomTasksAssembly"] = Path.GetFullPath(Path.Combine(".", "Microsoft.NET.Build.Containers.dll"));
@@ -53,7 +55,7 @@ public class TargetsTests
 
         var loggers = new List<ILogger>
         {
-            // new Microsoft.Build.Logging.BinaryLogger() {CollectProjectImports = Microsoft.Build.Logging.BinaryLogger.ProjectImportsCollectionMode.Embed, Verbosity = LoggerVerbosity.Diagnostic, Parameters = "LogFile=blah.binlog" },
+            // new global::Microsoft.Build.Logging.BinaryLogger() {CollectProjectImports = global::Microsoft.Build.Logging.BinaryLogger.ProjectImportsCollectionMode.Embed, Verbosity = LoggerVerbosity.Diagnostic, Parameters = $"LogFile={logFileName}.binlog" },
             new global::Microsoft.Build.Logging.ConsoleLogger(LoggerVerbosity.Detailed)
         };
         var collection = new ProjectCollection(null, loggers, ToolsetDefinitionLocations.Default);
@@ -61,7 +63,9 @@ public class TargetsTests
         {
             props[kvp.Key] = kvp.Value;
         }
-        return collection.LoadProject(CombinedTargetsLocation, props, null);
+        var p = collection.LoadProject(CombinedTargetsLocation, props, null);
+
+        return (p, collection);
     }
 
     [DataRow(true, "/app/foo.exe")]
@@ -69,10 +73,11 @@ public class TargetsTests
     [TestMethod]
     public void CanSetEntrypointArgsToUseAppHost(bool useAppHost, params string[] entrypointArgs)
     {
-        var project = InitProject(new()
+        var (project, dispose) = InitProject(new()
         {
             ["UseAppHost"] = useAppHost.ToString()
         });
+        using var _ = dispose;
         Assert.IsTrue(project.Build("ComputeContainerConfig"));
         var computedEntrypointArgs = project.GetItems("ContainerEntrypoint").Select(i => i.EvaluatedInclude).ToArray();
         foreach (var (First, Second) in entrypointArgs.Zip(computedEntrypointArgs))
@@ -89,12 +94,33 @@ public class TargetsTests
     [TestMethod]
     public void CanNormalizeInputContainerNames(string projectName, string expectedContainerImageName, bool shouldPass)
     {
-        var project = InitProject(new()
+        var (project, dispose) = InitProject(new()
         {
             ["AssemblyName"] = projectName
         });
+        using var _ = dispose;
         var instance = project.CreateProjectInstance(global::Microsoft.Build.Execution.ProjectInstanceSettings.None);
         Assert.AreEqual(shouldPass, instance.Build(new[]{"ComputeContainerConfig"}, null, null, out var outputs), "Build should have succeeded");
         Assert.AreEqual(expectedContainerImageName, instance.GetPropertyValue("ContainerImageName"));
+    }
+
+    [DataRow("7.0.100", true)]
+    [DataRow("8.0.100", true)]
+    [DataRow("7.0.100-preview.7", true)]
+    [DataRow("7.0.100-rc.1", true)]
+    [DataRow("6.0.100", false)]
+    [DataRow("7.0.100-preview.1", false)]
+    [TestMethod]
+    public void CanWarnOnInvalidSDKVersions(string sdkVersion, bool isAllowed) {
+        var (project, dispose) = InitProject(new()
+        {
+            ["NETCoreSdkVersion"] = sdkVersion,
+            ["PublishProfile"] = "DefaultContainer"
+        }, $"version-test-{sdkVersion}");
+        using var _ = dispose;
+        var instance = project.CreateProjectInstance(global::Microsoft.Build.Execution.ProjectInstanceSettings.None);
+        var derivedIsAllowed = Boolean.Parse(project.GetProperty("_IsSDKContainerAllowedVersion").EvaluatedValue);
+        // var buildResult = instance.Build(new[]{"_ContainerVerifySDKVersion"}, null, null, out var outputs);
+        Assert.AreEqual(isAllowed, derivedIsAllowed, $"SDK version {(isAllowed ? "should" : "should not")} have been allowed ");
     }
 }

--- a/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -8,6 +8,7 @@
                             AND (
                                  $(NETCoreSdkVersion.Contains('-preview.7'))
                                  OR $(NETCoreSdkVersion.Contains('-rc'))
+                                 OR $(NETCoreSdkVersion.Contains('-')) == false
                                 )
                           )">true</_IsSDKContainerAllowedVersion>
     </PropertyGroup>

--- a/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -1,4 +1,16 @@
 <Project>
+    <PropertyGroup>
+        <!-- Allow preview 7, any RC, or any stable version of 7 or higher -->
+        <_SDKMajorVersion>$(NETCoreSdkVersion.Substring(0,1))</_SDKMajorVersion>
+        <_SDKIsPrerelease Condition="$(NETCoreSdkVersion.Contains('-'))">true</_SDKIsPrerelease>
+        <_IsPreview7OrRCVersion Condition="$(NETCoreSdkVersion.Contains('-preview.7')) or $(NETCoreSdkVersion.Contains('-rc'))">true</_IsPreview7OrRCVersion>
+        <_IsStableSDKVersion Condition="$(NETCoreSdkVersion.Contains('-')) == false">true</_IsStableSDKVersion>
+        <_IsSDKContainerAllowedVersion Condition="$([MSBuild]::VersionLessThan($(_SDKMajorVersion), '7'))">false</_IsSDKContainerAllowedVersion>
+        <_IsSDKContainerAllowedVersion Condition="$([MSBuild]::VersionEquals($(_SDKMajorVersion), '7')) and ('$(_IsPreview7OrRCVersion)' == 'true' or '$(_IsStableSDKVersion)' == 'true')">true</_IsSDKContainerAllowedVersion>
+        <_IsSDKContainerAllowedVersion Condition="$([MSBuild]::VersionGreaterThan($(_SDKMajorVersion), '7'))">true</_IsSDKContainerAllowedVersion>
+        <_IsSDKContainerAllowedVersion Condition="'$(_IsSDKContainerAllowedVersion)' == ''">false</_IsSDKContainerAllowedVersion>
+    </PropertyGroup>
+
     <Target Name="_ContainerVerifySDKVersion"
         Condition="'$(WebPublishMethod)' == 'Container' or '$(PublishProfile)' == 'DefaultContainer'"
         BeforeTargets="AfterPublish">
@@ -6,11 +18,7 @@
             via the default Profile (PublishProfile = DefaultContainer), make sure they're on a supported SDK version.
             We do the explicit profile name check here because for preview6 for example the profile didn't exist, so we
             can't rely only on the WebPublishMethod. -->
-        <PropertyGroup>
-            <!-- Allow preview 7, any RC, or any stable version of 7 -->
-            <_IsAllowedVersion Condition="$(NETCoreSdkVersion.StartsWith('7.0.100-preview.7')) or $(NETCoreSdkVersion.StartsWith('7.0.100-rc')) or ($(NETCoreSdkVersion.StartsWith('7.0.10')) and $(NETCoreSdkVersion.Contains('-')) == false)">true</_IsAllowedVersion>
-        </PropertyGroup>
-        <Error Condition="'$(_IsAllowedVersion)' != 'true'" Code="CONTAINER002" Text="The current .NET SDK ($(NETCoreSdkVersion)) doesn't support containerization. Please use version 7.0.100-preview.7 or higher." />
+        <Error Condition="'$(_IsSDKContainerAllowedVersion)' != 'true'" Code="CONTAINER002" Text="The current .NET SDK ($(NETCoreSdkVersion)) doesn't support containerization. Please use version 7.0.100 or higher to enable containerization." />
     </Target>
 
     <Target Name="ComputeContainerConfig">

--- a/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -1,14 +1,15 @@
 <Project>
     <PropertyGroup>
-        <!-- Allow preview 7, any RC, or any stable version of 7 or higher -->
-        <_SDKMajorVersion>$(NETCoreSdkVersion.Substring(0,1))</_SDKMajorVersion>
-        <_SDKIsPrerelease Condition="$(NETCoreSdkVersion.Contains('-'))">true</_SDKIsPrerelease>
-        <_IsPreview7OrRCVersion Condition="$(NETCoreSdkVersion.Contains('-preview.7')) or $(NETCoreSdkVersion.Contains('-rc'))">true</_IsPreview7OrRCVersion>
-        <_IsStableSDKVersion Condition="$(NETCoreSdkVersion.Contains('-')) == false">true</_IsStableSDKVersion>
-        <_IsSDKContainerAllowedVersion Condition="$([MSBuild]::VersionLessThan($(_SDKMajorVersion), '7'))">false</_IsSDKContainerAllowedVersion>
-        <_IsSDKContainerAllowedVersion Condition="$([MSBuild]::VersionEquals($(_SDKMajorVersion), '7')) and ('$(_IsPreview7OrRCVersion)' == 'true' or '$(_IsStableSDKVersion)' == 'true')">true</_IsSDKContainerAllowedVersion>
-        <_IsSDKContainerAllowedVersion Condition="$([MSBuild]::VersionGreaterThan($(_SDKMajorVersion), '7'))">true</_IsSDKContainerAllowedVersion>
-        <_IsSDKContainerAllowedVersion Condition="'$(_IsSDKContainerAllowedVersion)' == ''">false</_IsSDKContainerAllowedVersion>
+        <_IsSDKContainerAllowedVersion>false</_IsSDKContainerAllowedVersion>
+        <!-- Anything newer than 7.0.100-preview.7 is supported -->
+        <_IsSDKContainerAllowedVersion
+            Condition="$([MSBuild]::VersionGreaterThan($(NetCoreSdkVersion), 7.0.100))
+                       OR ( $([MSBuild]::VersionEquals($(NetCoreSdkVersion), 7.0.100))
+                            AND (
+                                 $(NETCoreSdkVersion.Contains('-preview.7'))
+                                 OR $(NETCoreSdkVersion.Contains('-rc'))
+                                )
+                          )">true</_IsSDKContainerAllowedVersion>
     </PropertyGroup>
 
     <Target Name="_ContainerVerifySDKVersion"


### PR DESCRIPTION
Two primary goals here:

* Update the language in the existing version-check message to refer to 7.0.100 stable, since we are very close to GA.
* Expand the version checks to allow building on .NET 8 SDKs.