### PR TITLE
Cred retrieval failure info++

### DIFF
--- a/Microsoft.NET.Build.Containers/AuthHandshakeMessageHandler.cs
+++ b/Microsoft.NET.Build.Containers/AuthHandshakeMessageHandler.cs
@@ -1,4 +1,6 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using Microsoft.NET.Build.Containers.Credentials;
+
+using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Net.Http.Headers;
 using System.Runtime.CompilerServices;
@@ -97,7 +99,14 @@ public partial class AuthHandshakeMessageHandler : DelegatingHandler
         }
         else
         {
-            privateRepoCreds = await CredsProvider.GetCredentialsAsync(realm.Host);
+            try
+            {
+                privateRepoCreds = await CredsProvider.GetCredentialsAsync(realm.Host);
+            }
+            catch (Exception e)
+            {
+                throw new CredentialRetrievalException(realm.Host, e);
+            }
         }
 
         // use those creds when calling the token provider

--- a/Microsoft.NET.Build.Containers/AuthHandshakeMessageHandler.cs
+++ b/Microsoft.NET.Build.Containers/AuthHandshakeMessageHandler.cs
@@ -1,6 +1,7 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Net.Http.Headers;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
@@ -88,9 +89,17 @@ public partial class AuthHandshakeMessageHandler : DelegatingHandler
         string? credP = Environment.GetEnvironmentVariable("SDK_CONTAINER_REGISTRY_PWORD");
 
         // fetch creds for the host
-        DockerCredentials privateRepoCreds = (!string.IsNullOrEmpty(credU) && !string.IsNullOrEmpty(credP)) ?
-                                                                        new DockerCredentials(credU, credP) :
-                                                                        await CredsProvider.GetCredentialsAsync(realm.Host);
+        DockerCredentials? privateRepoCreds;
+
+        if (!string.IsNullOrEmpty(credU) && !string.IsNullOrEmpty(credP))
+        {
+            privateRepoCreds = new DockerCredentials(credU, credP);
+        }
+        else
+        {
+            privateRepoCreds = await CredsProvider.GetCredentialsAsync(realm.Host);
+        }
+
         // use those creds when calling the token provider
         var header = privateRepoCreds.Username == "<token>"
                         ? new AuthenticationHeaderValue("Bearer", privateRepoCreds.Password)

--- a/Microsoft.NET.Build.Containers/Credentials/CredentialRetrievalException.cs
+++ b/Microsoft.NET.Build.Containers/Credentials/CredentialRetrievalException.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace Microsoft.NET.Build.Containers.Credentials;
+
+internal class CredentialRetrievalException : Exception
+{
+	public CredentialRetrievalException(string registry, Exception innerException)
+		: base($"Failed retrieving credentials for \"{registry}\": {innerException.Message}", innerException)
+	{ }
+}

--- a/containerize/Properties/launchSettings.json
+++ b/containerize/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "containerize": {
       "commandName": "Project",
-      "commandLineArgs": "S:\\play\\container-demo\\bin\\Debug\\net6.0\\linux-x64\\ --baseregistry mcr.microsoft.com --baseimagename dotnet/runtime --outputregistry rainercontainer.azurecr.io --imagename donuts --imagetags 6.0 --workingdirectory app/ --entrypoint dotnet --entrypointargs run --labels foo=bar hello=world --ports 1234/tcp"
+      "commandLineArgs": "S:\\play\\container-demo\\bin\\Debug\\net6.0\\linux-x64\\ --baseregistry https://mcr.microsoft.com --baseimagename dotnet/runtime --outputregistry https://rainercontainer.azurecr.io --imagename donuts --imagetags 6.0 --workingdirectory app/ --entrypoint dotnet --entrypointargs run --labels foo=bar hello=world --ports 1234/tcp"
     }
   }
 }

--- a/containerize/Properties/launchSettings.json
+++ b/containerize/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "containerize": {
       "commandName": "Project",
-      "commandLineArgs": "S:\\play\\container-demo\\bin\\Debug\\net6.0\\linux-x64\\ --baseregistry https://mcr.microsoft.com --baseimagename dotnet/runtime --outputregistry https://rainercontainer.azurecr.io --imagename donuts --imagetags 6.0 --workingdirectory app/ --entrypoint dotnet --entrypointargs run --labels foo=bar hello=world --ports 1234/tcp"
+      "commandLineArgs": "S:\\play\\container-demo\\bin\\Debug\\net6.0\\linux-x64\\ --baseregistry mcr.microsoft.com --baseimagename dotnet/runtime --outputregistry rainercontainer.azurecr.io --imagename donuts --imagetags 6.0 --workingdirectory app/ --entrypoint dotnet --entrypointargs run --labels foo=bar hello=world --ports 1234/tcp"
     }
   }
 }


### PR DESCRIPTION
Example new `containerize` output is still not pretty but has more info!

```
Containerize: Uploading layer sha256:bd159e379b3b1bc0134341e4ffdeab5f966ec422ae04818bb69ecef08a823b05 to registry
Containerize: error CONTAINER001: Failed to push to output registry: System.AggregateException: One or more errors occurred. (Failed retrieving credentials for "rainercontainer.azurecr.io": Failed to execute 'docker-credential-desktop get':
credentials not found in native keychain
)
 ---> Microsoft.NET.Build.Containers.Credentials.CredentialRetrievalException: Failed retrieving credentials for "rainercontainer.azurecr.io": Failed to execute 'docker-credential-desktop get':
credentials not found in native keychain

 ---> Valleysoft.DockerCredsProvider.CredsNotFoundException: Failed to execute 'docker-credential-desktop get':
credentials not found in native keychain

   at Valleysoft.DockerCredsProvider.NativeStore.ExecuteCredHelper(String command, String input)
   at Valleysoft.DockerCredsProvider.NativeStore.GetCredentialsAsync(String registry)
   at Valleysoft.DockerCredsProvider.CredsProvider.GetCredentialsAsync(String registry, IFileSystem fileSystem, IProcessService processService)
   at Microsoft.NET.Build.Containers.AuthHandshakeMessageHandler.GetTokenAsync(Uri realm, String service, String scope, CancellationToken cancellationToken) in S:\System.Containers\Microsoft.NET.Build.Containers\AuthHandshakeMessageHandler.cs:line 104
   --- End of inner exception stack trace ---
   at Microsoft.NET.Build.Containers.AuthHandshakeMessageHandler.GetTokenAsync(Uri realm, String service, String scope, CancellationToken cancellationToken) in S:\System.Containers\Microsoft.NET.Build.Containers\AuthHandshakeMessageHandler.cs:line 108
   at Microsoft.NET.Build.Containers.AuthHandshakeMessageHandler.SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) in S:\System.Containers\Microsoft.NET.Build.Containers\AuthHandshakeMessageHandler.cs:line 158
   at System.Net.Http.HttpClient.<SendAsync>g__Core|83_0(HttpRequestMessage request, HttpCompletionOption completionOption, CancellationTokenSource cts, Boolean disposeCts, CancellationTokenSource pendingRequestsCts, CancellationToken originalCancellationToken)
   at Microsoft.NET.Build.Containers.Registry.BlobAlreadyUploaded(String name, String digest, HttpClient client) in S:\System.Containers\Microsoft.NET.Build.Containers\Registry.cs:line 146
   at Microsoft.NET.Build.Containers.Registry.Push(Image x, String name, String tag, String baseName, Action`1 logProgressMessage) in S:\System.Containers\Microsoft.NET.Build.Containers\Registry.cs:line 184
   --- End of inner exception stack trace ---
   at System.Threading.Tasks.Task.ThrowIfExceptional(Boolean includeTaskCanceledExceptions)
   at System.Threading.Tasks.Task.Wait(Int32 millisecondsTimeout, CancellationToken cancellationToken)
   at System.Threading.Tasks.Task.Wait()
   at Microsoft.NET.Build.Containers.ContainerBuilder.Containerize(DirectoryInfo folder, String workingDir, String registryName, String baseName, String baseTag, String[] entrypoint, String[] entrypointArgs, String imageName, String[] imageTags, String outputRegistry, String[] labels, Port[] exposedPorts, String[] envVars) in S:\System.Containers\Microsoft.NET.Build.Containers\ContainerBuilder.cs:line 75
```