### PR TITLE
Bump Valleysoft.DockerCredsProvider to 2.1.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,6 +14,6 @@
         <PackageVersion Include="GitHubActionsTestLogger" Version="2.0.1" />
         <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
         <PackageVersion Include="Microsoft.Build.Locator" Version="1.5.5" />
-	    <PackageVersion Include="Valleysoft.DockerCredsProvider" Version="1.2.0" />
+	    <PackageVersion Include="Valleysoft.DockerCredsProvider" Version="2.1.0" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
This fixes docker config file location and credential helper invocation on Windows.