### PR TITLE
Fix aggregation of lists of parameters to the tool task

### DIFF
--- a/Microsoft.NET.Build.Containers/CreateNewImageToolTask.cs
+++ b/Microsoft.NET.Build.Containers/CreateNewImageToolTask.cs
@@ -186,12 +186,12 @@ public class CreateNewImage : ToolTask
                " --outputregistry " + OutputRegistry +
                " --imagename " + ImageName +
                " --workingdirectory " + WorkingDirectory +
-               (Entrypoint.Length > 0 ? " --entrypoint " + Entrypoint.Select((i) => i.ItemSpec).Aggregate((i, s) => s += i + " ") : "") +
-               (Labels.Length > 0 ? " --labels " + Labels.Select((i) => i.ItemSpec + "=" + Quote(i.GetMetadata("Value"))).Aggregate((i, s) => s += i + " ") : "") +
-               (ImageTags.Length > 0 ? " --imagetags " + ImageTags.Select((i) => Quote(i.ItemSpec)).Aggregate((i, s) => s += i + " ") : "") +
-               (EntrypointArgs.Length > 0 ? " --entrypointargs " + EntrypointArgs.Select((i) => i.ItemSpec).Aggregate((i, s) => s += i + " ") : "") +
-               (ExposedPorts.Length > 0 ? " --ports " + ExposedPorts.Select((i) => i.ItemSpec + "/" + i.GetMetadata("Type")).Aggregate((i, s) => s += i + " ") : "") +
-               (ContainerEnvironmentVariables.Length > 0 ? " --environmentvariables " + ContainerEnvironmentVariables.Select((i) => i.ItemSpec + "=" + Quote(i.GetMetadata("Value"))).Aggregate((i, s) => s += i + " ") : "");
+               (Entrypoint.Length > 0 ? " --entrypoint " + String.Join(" ", Entrypoint.Select((i) => i.ItemSpec)) : "") +
+               (Labels.Length > 0 ? " --labels " + String.Join(" ", Labels.Select((i) => i.ItemSpec + "=" + Quote(i.GetMetadata("Value")))) : "") +
+               (ImageTags.Length > 0 ? " --imagetags " + String.Join(" ", ImageTags.Select((i) => Quote(i.ItemSpec))) : "") +
+               (EntrypointArgs.Length > 0 ? " --entrypointargs " + String.Join(" ", EntrypointArgs.Select((i) => i.ItemSpec)) : "") +
+               (ExposedPorts.Length > 0 ? " --ports " + String.Join(" ", ExposedPorts.Select((i) => i.ItemSpec + "/" + i.GetMetadata("Type"))) : "") +
+               (ContainerEnvironmentVariables.Length > 0 ? " --environmentvariables " + String.Join(" ", ContainerEnvironmentVariables.Select((i) => i.ItemSpec + "=" + Quote(i.GetMetadata("Value")))) : "");
     }
 
     private string Quote(string path)

--- a/Microsoft.NET.Build.Containers/CreateNewImageToolTask.cs
+++ b/Microsoft.NET.Build.Containers/CreateNewImageToolTask.cs
@@ -187,11 +187,11 @@ public class CreateNewImage : ToolTask
                " --imagename " + ImageName +
                " --workingdirectory " + WorkingDirectory +
                (Entrypoint.Length > 0 ? " --entrypoint " + Entrypoint.Select((i) => i.ItemSpec).Aggregate((i, s) => s += i + " ") : "") +
-               (Labels.Length > 0 ? " --labels " + Labels.Select((i) => i.ItemSpec + "=" + i.GetMetadata("Value")).Aggregate((i, s) => s += i + " ") : "") +
-               (ImageTags.Length > 0 ? " --imagetags " + ImageTags.Select((i) => i.ItemSpec).Aggregate((i, s) => s += i + " ") : "") +
+               (Labels.Length > 0 ? " --labels " + Labels.Select((i) => i.ItemSpec + "=" + Quote(i.GetMetadata("Value"))).Aggregate((i, s) => s += i + " ") : "") +
+               (ImageTags.Length > 0 ? " --imagetags " + ImageTags.Select((i) => Quote(i.ItemSpec)).Aggregate((i, s) => s += i + " ") : "") +
                (EntrypointArgs.Length > 0 ? " --entrypointargs " + EntrypointArgs.Select((i) => i.ItemSpec).Aggregate((i, s) => s += i + " ") : "") +
                (ExposedPorts.Length > 0 ? " --ports " + ExposedPorts.Select((i) => i.ItemSpec + "/" + i.GetMetadata("Type")).Aggregate((i, s) => s += i + " ") : "") +
-               (ContainerEnvironmentVariables.Length > 0 ? " --environmentvariables " + ContainerEnvironmentVariables.Select((i) => i.ItemSpec + "=" + i.GetMetadata("Value")).Aggregate((i, s) => s += i + " ") : "");
+               (ContainerEnvironmentVariables.Length > 0 ? " --environmentvariables " + ContainerEnvironmentVariables.Select((i) => i.ItemSpec + "=" + Quote(i.GetMetadata("Value"))).Aggregate((i, s) => s += i + " ") : "");
     }
 
     private string Quote(string path)


### PR DESCRIPTION
Various lists of parameters weren't being aggregated correctly on the `containerize` tool call, which led to failures during publishing.  Instead of rolling our own Aggregate, I used String.Join to handle the logic and the commandlines were corrected, and publishes resumed working.

I found this while adding additional Labels to a publish, but verified the problem with tags as well.