### PR TITLE
Auth caching, attempt 2

### DIFF
--- a/Microsoft.NET.Build.Containers/AuthHeaderCache.cs
+++ b/Microsoft.NET.Build.Containers/AuthHeaderCache.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.NET.Build.Containers;
+
+internal static class AuthHeaderCache
+{
+
+    private static ConcurrentDictionary<string, AuthenticationHeaderValue> HostAuthenticationCache = new();
+
+    public static bool TryGet(Uri uri, [NotNullWhen(true)] out AuthenticationHeaderValue? header)
+    {
+        return HostAuthenticationCache.TryGetValue(GetCacheKey(uri), out header);
+    }
+
+    public static AuthenticationHeaderValue AddOrUpdate(Uri uri, AuthenticationHeaderValue header)
+    {
+        return HostAuthenticationCache.AddOrUpdate(GetCacheKey(uri), header, (_, _) => header);
+    }
+
+    private static string GetCacheKey(Uri uri)
+    {
+        return uri.Host + uri.AbsolutePath;
+    }
+}


### PR DESCRIPTION
The last attempt at caching was too general and got backed out in #223. What we really want is by "scope" but we don't have a great way to predict a scope in advance, they're generally given back by the server.

This time, I'm trying to cache by URL (excluding query string), which will be very helpful when hitting chunked upload URLs over and over.

See details in the second commit message especially.

- Enable auth caching by URL
- Quirk for ACR 401 on ".../blobs/uploads/"
