### PR TITLE
Support tags passed into ParseContainerProperties

### DIFF
--- a/Microsoft.NET.Build.Containers/ParseContainerProperties.cs
+++ b/Microsoft.NET.Build.Containers/ParseContainerProperties.cs
@@ -118,7 +118,7 @@ public class ParseContainerProperties : Microsoft.Build.Utilities.Task
                 Log.LogError(null, "CONTAINER003", "Container.InvalidTag", null, 0, 0, 0, 0, $"Invalid {nameof(ContainerImageTag)} provided: {{0}}. Image tags must be alphanumeric, underscore, hyphen, or period.", ContainerImageTag);
             }
         }
-        else if (ContainerImageTags.Length != 0 && !TryValidateTags(ContainerImageTags, out var valids, out var invalids))
+        else if (ContainerImageTags.Length != 0 && TryValidateTags(ContainerImageTags, out var valids, out var invalids))
         {
             validTags = valids;
             if (invalids.Any())

--- a/Test.Microsoft.NET.Build.Containers.Filesystem/ParseContainerPropertiesTests.cs
+++ b/Test.Microsoft.NET.Build.Containers.Filesystem/ParseContainerPropertiesTests.cs
@@ -15,7 +15,7 @@ namespace Test.Microsoft.NET.Build.Containers.Tasks
             task.FullyQualifiedBaseImageName = "mcr.microsoft.com/dotnet/runtime:6.0";
             task.ContainerRegistry = "localhost:5010";
             task.ContainerImageName = "dotnet/testimage";
-            task.ContainerImageTags = new[] { "5.0" };
+            task.ContainerImageTags = new[] { "5.0", "latest" };
 
             Assert.IsTrue(task.Execute());
             Assert.AreEqual("mcr.microsoft.com", task.ParsedContainerRegistry);
@@ -23,7 +23,7 @@ namespace Test.Microsoft.NET.Build.Containers.Tasks
             Assert.AreEqual("6.0", task.ParsedContainerTag);
 
             Assert.AreEqual("dotnet/testimage", task.NewContainerImageName);
-            new[] { "5.0" }.SequenceEqual(task.NewContainerTags);
+            CollectionAssert.AreEquivalent(new[] { "5.0", "latest" }, task.NewContainerTags);
         }
 
         [TestMethod]
@@ -42,7 +42,7 @@ namespace Test.Microsoft.NET.Build.Containers.Tasks
 
             Assert.AreEqual("localhost:5010", task.NewContainerRegistry);
             Assert.AreEqual("dotnet/testimage", task.NewContainerImageName);
-            new[] { "5.0" }.SequenceEqual(task.NewContainerTags);
+            CollectionAssert.AreEquivalent(new[] { "5.0" }, task.NewContainerTags);
         }
 
         [TestMethod]
@@ -61,7 +61,7 @@ namespace Test.Microsoft.NET.Build.Containers.Tasks
 
             Assert.AreEqual("localhost:5010", task.NewContainerRegistry);
             Assert.AreEqual("dotnet/testimage", task.NewContainerImageName);
-            new[] { "5.0" }.SequenceEqual(task.NewContainerTags);
+            CollectionAssert.AreEquivalent(new[] { "5.0" }, task.NewContainerTags);
         }
 
         [TestMethod]
@@ -81,7 +81,7 @@ namespace Test.Microsoft.NET.Build.Containers.Tasks
             Assert.AreEqual("6-0", task.ParsedContainerTag);
 
             Assert.AreEqual("dotnet/testimage", task.NewContainerImageName);
-            new[] { "5.0" }.SequenceEqual(task.NewContainerTags);
+            CollectionAssert.AreEquivalent(new[] { "5.0" }, task.NewContainerTags);
         }
 
         [TestMethod]


### PR DESCRIPTION
A logic error caused ParseContainerProperties to fail if multi-valued
tags were passed into ContainerImageTags. A test error made that non-
obvious.

Fix the tests to use CollectionAssert methods, and invert the check
on TryValidateTags so that when the tags are valid we respect them.

Fixes #236.
