### PR TITLE
Error when no tags are given to CreateNewImage

### DIFF
--- a/Microsoft.NET.Build.Containers/CreateNewImage.Interface.cs
+++ b/Microsoft.NET.Build.Containers/CreateNewImage.Interface.cs
@@ -49,6 +49,7 @@ partial class CreateNewImage
     /// <summary>
     /// The tag to associate with the new image.
     /// </summary>
+    [Required]
     public string[] ImageTags { get; set; }
 
     /// <summary>

--- a/Test.Microsoft.NET.Build.Containers.Filesystem/CreateNewImageTests.cs
+++ b/Test.Microsoft.NET.Build.Containers.Filesystem/CreateNewImageTests.cs
@@ -49,6 +49,7 @@ public class CreateNewImageTests
         task.OutputRegistry = "localhost:5010";
         task.PublishDirectory = Path.Combine(newProjectDir.FullName, "bin", "release", "net7.0");
         task.ImageName = "dotnet/testimage";
+        task.ImageTags = new[] { "latest" };
         task.WorkingDirectory = "app/";
         task.Entrypoint = new TaskItem[] { new("dotnet"), new("build") };
 
@@ -101,7 +102,7 @@ public class CreateNewImageTests
         Assert.AreEqual("6.0", pcp.ParsedContainerTag);
 
         Assert.AreEqual("dotnet/testimage", pcp.NewContainerImageName);
-        new []{ "5.0", "latest"}.SequenceEqual(pcp.NewContainerTags);
+        CollectionAssert.AreEquivalent(new []{ "5.0", "latest"}, pcp.NewContainerTags);
 
         CreateNewImage cni = new CreateNewImage();
         cni.BaseRegistry = pcp.ParsedContainerRegistry;


### PR DESCRIPTION
If something caused ImageTags to be empty, the foreach-tag-push loop
would silently do nothing, which is a confusing user experience.

Instead, emit an error and fail. Fixes #240.
