### PR TITLE
Single definition for task inputs/outputs

### DIFF
--- a/Microsoft.NET.Build.Containers/CreateNewImage.Interface.cs
+++ b/Microsoft.NET.Build.Containers/CreateNewImage.Interface.cs
@@ -1,0 +1,122 @@
+﻿using System;
+
+using Microsoft.Build.Framework;
+
+namespace Microsoft.NET.Build.Containers.Tasks;
+
+partial class CreateNewImage
+{
+    /// <summary>
+    /// The path to the folder containing `containerize.dll`.
+    /// </summary>
+    /// <remarks>
+    /// Used only for the ToolTask implementation of this task.
+    /// </remarks>
+    public string ContainerizeDirectory { get; set; }
+
+    /// <summary>
+    /// The base registry to pull from.
+    /// Ex: mcr.microsoft.com
+    /// </summary>
+    [Required]
+    public string BaseRegistry { get; set; }
+
+    /// <summary>
+    /// The base image to pull.
+    /// Ex: dotnet/runtime
+    /// </summary>
+    [Required]
+    public string BaseImageName { get; set; }
+
+    /// <summary>
+    /// The base image tag.
+    /// Ex: 6.0
+    /// </summary>
+    [Required]
+    public string BaseImageTag { get; set; }
+
+    /// <summary>
+    /// The registry to push to.
+    /// </summary>
+    public string OutputRegistry { get; set; }
+
+    /// <summary>
+    /// The name of the output image that will be pushed to the registry.
+    /// </summary>
+    [Required]
+    public string ImageName { get; set; }
+
+    /// <summary>
+    /// The tag to associate with the new image.
+    /// </summary>
+    public string[] ImageTags { get; set; }
+
+    /// <summary>
+    /// The directory for the build outputs to be published.
+    /// Constructed from "$(MSBuildProjectDirectory)\$(PublishDir)"
+    /// </summary>
+    [Required]
+    public string PublishDirectory { get; set; }
+
+    /// <summary>
+    /// The working directory of the container.
+    /// </summary>
+    [Required]
+    public string WorkingDirectory { get; set; }
+
+    /// <summary>
+    /// The entrypoint application of the container.
+    /// </summary>
+    [Required]
+    public ITaskItem[] Entrypoint { get; set; }
+
+    /// <summary>
+    /// Arguments to pass alongside Entrypoint.
+    /// </summary>
+    public ITaskItem[] EntrypointArgs { get; set; }
+
+    /// <summary>
+    /// Ports that the application declares that it will use.
+    /// Note that this means nothing to container hosts, by default -
+    /// it's mostly documentation.
+    /// </summary>
+    public ITaskItem[] ExposedPorts { get; set; }
+
+    /// <summary>
+    /// Labels that the image configuration will include in metadata
+    /// </summary>
+    public ITaskItem[] Labels { get; set; }
+
+    /// <summary>
+    /// Container environment variables to set.
+    /// </summary>
+    public ITaskItem[] ContainerEnvironmentVariables { get; set; }
+
+    [Output]
+    public string GeneratedContainerManifest { get; set; }
+
+    [Output]
+    public string GeneratedContainerConfiguration { get; set; }
+
+    public CreateNewImage()
+    {
+        ContainerizeDirectory = "";
+        ToolExe = "";
+        ToolPath = "";
+        BaseRegistry = "";
+        BaseImageName = "";
+        BaseImageTag = "";
+        OutputRegistry = "";
+        ImageName = "";
+        ImageTags = Array.Empty<string>();
+        PublishDirectory = "";
+        WorkingDirectory = "";
+        Entrypoint = Array.Empty<ITaskItem>();
+        EntrypointArgs = Array.Empty<ITaskItem>();
+        Labels = Array.Empty<ITaskItem>();
+        ExposedPorts = Array.Empty<ITaskItem>();
+        ContainerEnvironmentVariables = Array.Empty<ITaskItem>();
+        GeneratedContainerConfiguration = "";
+        GeneratedContainerManifest = "";
+    }
+}

--- a/Microsoft.NET.Build.Containers/CreateNewImage.cs
+++ b/Microsoft.NET.Build.Containers/CreateNewImage.cs
@@ -2,133 +2,21 @@
 
 namespace Microsoft.NET.Build.Containers.Tasks;
 
-public class CreateNewImage : Microsoft.Build.Utilities.Task
+public partial class CreateNewImage : Microsoft.Build.Utilities.Task
 {
-
     /// <summary>
-    /// Unused. This exists so we can call a single task invocation in PublishContainer.
-    /// </summary>
-    public string ContainerizeDirectory { get; set; }
-
-    /// <summary>
-    /// Unused. See above.
+    /// Unused. For interface parity with the ToolTask implementation of the task.
     /// </summary>
     public string ToolExe { get; set; }
 
     /// <summary>
-    /// Unused. See above.
+    /// Unused. For interface parity with the ToolTask implementation of the task.
     /// </summary>
     public string ToolPath { get; set; }
-
-    /// <summary>
-    /// The base registry to pull from.
-    /// Ex: mcr.microsoft.com
-    /// </summary>
-    [Required]
-    public string BaseRegistry { get; set; }
-
-    /// <summary>
-    /// The base image to pull.
-    /// Ex: dotnet/runtime
-    /// </summary>
-    [Required]
-    public string BaseImageName { get; set; }
-
-    /// <summary>
-    /// The base image tag.
-    /// Ex: 6.0
-    /// </summary>
-    [Required]
-    public string BaseImageTag { get; set; }
-
-    /// <summary>
-    /// The registry to push to.
-    /// </summary>
-    public string OutputRegistry { get; set; }
-
-    /// <summary>
-    /// The name of the output image that will be pushed to the registry.
-    /// </summary>
-    [Required]
-    public string ImageName { get; set; }
-
-    /// <summary>
-    /// The tag to associate with the new image.
-    /// </summary>
-    public string[] ImageTags { get; set; }
-
-    /// <summary>
-    /// The directory for the build outputs to be published.
-    /// Constructed from "$(MSBuildProjectDirectory)\$(PublishDir)"
-    /// </summary>
-    [Required]
-    public string PublishDirectory { get; set; }
-
-    /// <summary>
-    /// The working directory of the container.
-    /// </summary>
-    [Required]
-    public string WorkingDirectory { get; set; }
-
-    /// <summary>
-    /// The entrypoint application of the container.
-    /// </summary>
-    [Required]
-    public ITaskItem[] Entrypoint { get; set; }
-
-    /// <summary>
-    /// Arguments to pass alongside Entrypoint.
-    /// </summary>
-    public ITaskItem[] EntrypointArgs { get; set; }
-
-    /// <summary>
-    /// Ports that the application declares that it will use.
-    /// Note that this means nothing to container hosts, by default -
-    /// it's mostly documentation.
-    /// </summary>
-    public ITaskItem[] ExposedPorts { get; set; }
-
-    /// <summary>
-    /// Labels that the image configuration will include in metadata
-    /// </summary>
-    public ITaskItem[] Labels { get; set; }
-
-    /// <summary>
-    /// Container environment variables to set.
-    /// </summary>
-    public ITaskItem[] ContainerEnvironmentVariables { get; set; }
-
-    [Output]
-    public string GeneratedContainerManifest { get; set; }
-
-    [Output]
-    public string GeneratedContainerConfiguration { get; set; }
 
     private bool IsDockerPush { get => String.IsNullOrEmpty(OutputRegistry); }
 
     private bool IsDockerPull { get => String.IsNullOrEmpty(BaseRegistry); }
-
-    public CreateNewImage()
-    {
-        ContainerizeDirectory = "";
-        ToolExe = "";
-        ToolPath = "";
-        BaseRegistry = "";
-        BaseImageName = "";
-        BaseImageTag = "";
-        OutputRegistry = "";
-        ImageName = "";
-        ImageTags = Array.Empty<string>();
-        PublishDirectory = "";
-        WorkingDirectory = "";
-        Entrypoint = Array.Empty<ITaskItem>();
-        EntrypointArgs = Array.Empty<ITaskItem>();
-        Labels = Array.Empty<ITaskItem>();
-        ExposedPorts = Array.Empty<ITaskItem>();
-        ContainerEnvironmentVariables = Array.Empty<ITaskItem>();
-        GeneratedContainerConfiguration = "";
-        GeneratedContainerManifest = "";
-    }
 
     private void SetPorts(Image image, ITaskItem[] exposedPorts)
     {

--- a/Microsoft.NET.Build.Containers/CreateNewImageToolTask.cs
+++ b/Microsoft.NET.Build.Containers/CreateNewImageToolTask.cs
@@ -10,95 +10,8 @@ using Microsoft.Build.Utilities;
 /// <summary>
 /// This task will shell out to the net7.0-targeted application for VS scenarios.
 /// </summary>
-public class CreateNewImage : ToolTask
+public partial class CreateNewImage : ToolTask
 {
-    /// <summary>
-    /// The path to the folder containing `containerize.dll`.
-    /// </summary>
-    [Required]
-    public string ContainerizeDirectory { get; set; }
-
-    [Required]
-    public string BaseRegistry { get; set; }
-
-    /// <summary>
-    /// The base image to pull.
-    /// Ex: dotnet/runtime
-    /// </summary>
-    [Required]
-    public string BaseImageName { get; set; }
-
-    /// <summary>
-    /// The base image tag.
-    /// Ex: 6.0
-    /// </summary>
-    [Required]
-    public string BaseImageTag { get; set; }
-
-    /// <summary>
-    /// The registry to push to.
-    /// </summary>
-    [Required]
-    public string OutputRegistry { get; set; }
-
-    /// <summary>
-    /// The name of the output image that will be pushed to the registry.
-    /// </summary>
-    [Required]
-    public string ImageName { get; set; }
-
-    /// <summary>
-    /// The tag to associate with the new image.
-    /// </summary>
-    public ITaskItem[] ImageTags { get; set; }
-
-    /// <summary>
-    /// The directory for the build outputs to be published.
-    /// Constructed from "$(MSBuildProjectDirectory)\$(PublishDir)"
-    /// </summary>
-    [Required]
-    public string PublishDirectory { get; set; }
-
-    /// <summary>
-    /// The working directory of the container.
-    /// </summary>
-    [Required]
-    public string WorkingDirectory { get; set; }
-
-    /// <summary>
-    /// The entrypoint application of the container.
-    /// </summary>
-    [Required]
-    public ITaskItem[] Entrypoint { get; set; }
-
-    /// <summary>
-    /// Arguments to pass alongside Entrypoint.
-    /// </summary>
-    public ITaskItem[] EntrypointArgs { get; set; }
-
-    /// <summary>
-    /// Labels that the image configuration will include in metadata
-    /// </summary>
-    public ITaskItem[] Labels { get; set; }
-
-    /// <summary>
-    /// Ports that the application declares that it will use.
-    /// Note that this means nothing to container hosts, by default -
-    /// it's mostly documentation.
-    /// </summary>
-    public ITaskItem[] ExposedPorts { get; set; }
-
-    /// <summary>
-    /// Container environment variables to set.
-    /// </summary>
-    public ITaskItem[] ContainerEnvironmentVariables { get; set; }
-
-    [Output]
-    public string GeneratedContainerManifest { get; set; }
-
-    [Output]
-    public string GeneratedContainerConfiguration { get; set; }
- 
     // Unused, ToolExe is set via targets and overrides this.
     protected override string ToolName => "dotnet";
 
@@ -116,27 +29,6 @@ public class CreateNewImage : ToolTask
 
             return path;
         }
-    }
-
-    public CreateNewImage()
-    {
-        ContainerizeDirectory = "";
-        BaseRegistry = "";
-        BaseImageName = "";
-        BaseImageTag = "";
-        OutputRegistry = "";
-        ImageName = "";
-        ImageTags = Array.Empty<ITaskItem>();
-        PublishDirectory = "";
-        WorkingDirectory = "";
-        Entrypoint = Array.Empty<ITaskItem>();
-        EntrypointArgs = Array.Empty<ITaskItem>();
-        Labels = Array.Empty<ITaskItem>();
-        ExposedPorts = Array.Empty<ITaskItem>();
-        ContainerEnvironmentVariables = Array.Empty<ITaskItem>();
-        extractionInfo = (false, string.Empty, string.Empty);
-        GeneratedContainerConfiguration = "";
-        GeneratedContainerManifest = "";
     }
 
     protected override string GenerateFullPathToTool() => Quote(Path.Combine(DotNetPath, ToolExe));
@@ -188,7 +80,7 @@ public class CreateNewImage : ToolTask
                " --workingdirectory " + WorkingDirectory +
                (Entrypoint.Length > 0 ? " --entrypoint " + String.Join(" ", Entrypoint.Select((i) => i.ItemSpec)) : "") +
                (Labels.Length > 0 ? " --labels " + String.Join(" ", Labels.Select((i) => i.ItemSpec + "=" + Quote(i.GetMetadata("Value")))) : "") +
-               (ImageTags.Length > 0 ? " --imagetags " + String.Join(" ", ImageTags.Select((i) => Quote(i.ItemSpec))) : "") +
+               (ImageTags.Length > 0 ? " --imagetags " + String.Join(" ", ImageTags.Select((i) => Quote(i))) : "") +
                (EntrypointArgs.Length > 0 ? " --entrypointargs " + String.Join(" ", EntrypointArgs.Select((i) => i.ItemSpec)) : "") +
                (ExposedPorts.Length > 0 ? " --ports " + String.Join(" ", ExposedPorts.Select((i) => i.ItemSpec + "/" + i.GetMetadata("Type"))) : "") +
                (ContainerEnvironmentVariables.Length > 0 ? " --environmentvariables " + String.Join(" ", ContainerEnvironmentVariables.Select((i) => i.ItemSpec + "=" + Quote(i.GetMetadata("Value")))) : "");

--- a/Microsoft.NET.Build.Containers/Microsoft.NET.Build.Containers.csproj
+++ b/Microsoft.NET.Build.Containers/Microsoft.NET.Build.Containers.csproj
@@ -30,6 +30,7 @@
     <Compile Remove="*.*" />
     <Compile Include="ReferenceParser.cs" />
     <Compile Include="ParseContainerProperties.cs" />
+    <Compile Include="CreateNewImage.Interface.cs" />
     <Compile Include="CreateNewImageToolTask.cs" />
     <Compile Include="ContainerHelpers.cs" />
     <Compile Include="net472Definitions.cs" />


### PR DESCRIPTION
Define the inputs and outputs of the two task implementations in a single
file, pulled into both classes.

Fixes #171.
