### PR TITLE
Do windows and ubuntu docker builds to enhance coverage.

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -4,15 +4,24 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: 
+    branches:
     - main
     - v*
-  workflow_dispatch:  
+  workflow_dispatch:
 
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # GitHub runners for MacOS don't come with Docker due to licensing. Windows and Ubuntu do.
+        # Windows has a Microsoft-sponsored license, Ubuntu uses an azure-derived Docker CLI.
+        os:
+          - ubuntu-latest
+          - windows-latest
+          # - macos-latest
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
We can't do MacOS easily (looking into podman maybe here?) due to licensing issues.