### PR TITLE
Reorder disposing of the CryptoStream and HashAlgorithm to avoid ODE

### DIFF
--- a/Microsoft.NET.Build.Containers/Layer.cs
+++ b/Microsoft.NET.Build.Containers/Layer.cs
@@ -139,8 +139,10 @@ public record struct Layer
         {
             try
             {
-                hashAlgorithm.Dispose();
+                // dispose hashAlgorithm after sha256Stream since sha256Stream references/uses it
                 sha256Stream.Dispose();
+                hashAlgorithm.Dispose();
+
                 compressionStream.Dispose();
             }
             finally


### PR DESCRIPTION
Fix #246

___________

I'm not sure how to test this. Somehow I'd need to get an exception thrown before calling `HashDigestGZipStream.GetHash()`. Ideas welcome.

cc @baronfel @rainersigwald 