### PR TITLE
Upload all blobs as 64k chunks

### DIFF
--- a/Microsoft.NET.Build.Containers/Registry.cs
+++ b/Microsoft.NET.Build.Containers/Registry.cs
@@ -160,24 +160,9 @@ public record struct Registry(Uri BaseUri)
             //    content.Headers.Add("Content-Range", $"0-{contents.Length - 1}");
             Debug.Assert(content.Headers.TryAddWithoutValidation("Content-Range", $"{chunkStart}-{chunkStart + bytesRead - 1}"));
 
-            HttpResponseMessage? patchResponse = null;
-            for (int retry = 0; retry < 3; retry++)
-            {
-                ExceptionDispatchInfo? e = null;
-                try
-                {
-                    patchResponse = await client.PatchAsync(patchUri, content);
-                    break;
-                }
-                catch (Exception ex)
-                {
-                    e = ExceptionDispatchInfo.Capture(ex);
-                }
+            HttpResponseMessage patchResponse = await client.PatchAsync(patchUri, content);
 
-                e.Throw();
-            }
-
-            if (patchResponse!.StatusCode != HttpStatusCode.Accepted)
+            if (patchResponse.StatusCode != HttpStatusCode.Accepted)
             {
                 string errorMessage = $"Failed to upload blob to {patchUri}; recieved {patchResponse.StatusCode} with detail {await patchResponse.Content.ReadAsStringAsync()}";
                 throw new ApplicationException(errorMessage);

--- a/Microsoft.NET.Build.Containers/Registry.cs
+++ b/Microsoft.NET.Build.Containers/Registry.cs
@@ -6,6 +6,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
+using System.Runtime.ExceptionServices;
 using System.Text;
 using System.Text.Json.Nodes;
 using System.Xml.Linq;
@@ -16,6 +17,7 @@ public record struct Registry(Uri BaseUri)
 {
     private const string DockerManifestV2 = "application/vnd.docker.distribution.manifest.v2+json";
     private const string DockerContainerV1 = "application/vnd.docker.container.image.v1+json";
+    private const int MaxChunkSizeBytes = 1024 * 64;
 
     private string RegistryName { get; } = BaseUri.Host;
 
@@ -132,17 +134,92 @@ public record struct Registry(Uri BaseUri)
             x = new UriBuilder(new Uri(BaseUri, pushResponse.Headers.Location?.OriginalString ?? ""));
         }
 
+        Uri patchUri = x.Uri;
+
         x.Query += $"&digest={Uri.EscapeDataString(digest)}";
 
-        // TODO: consider chunking
-        StreamContent content = new StreamContent(contents);
-        content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
-        content.Headers.ContentLength = contents.Length;
-        HttpResponseMessage putResponse = await client.PutAsync(x.Uri, content);
+        Uri putUri = x.Uri;
 
-        string resp = await putResponse.Content.ReadAsStringAsync();
+        // TODO: this chunking is super tiny and probably not necessary; what does the docker client do
+        //       and can we be smarter?
 
-        putResponse.EnsureSuccessStatusCode();
+        byte[] chunkBackingStore = new byte[MaxChunkSizeBytes];
+
+        int chunkCount = 0;
+        int chunkStart = 0;
+
+        while (contents.Position < contents.Length)
+        {
+            int bytesRead = await contents.ReadAsync(chunkBackingStore);
+
+            ByteArrayContent content = new (chunkBackingStore, offset: 0, count: bytesRead);
+            content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+            content.Headers.ContentLength = bytesRead;
+            //HttpResponseMessage putResponse = await client.PutAsync(putUri, content);
+
+            //string resp = await putResponse.Content.ReadAsStringAsync();
+
+            //putResponse.EnsureSuccessStatusCode();
+
+            // Chunked upload
+            //content.Headers.ContentRange = new(from:0, to: contents.Length - 1);
+
+            // manual because ACR throws an error with the .NET type {"Range":"bytes 0-84521/*","Reason":"the Content-Range header format is invalid"}
+            //content.Headers.Add("Content-Range", $"0-{contents.Length - 1}");
+            Debug.Assert(content.Headers.TryAddWithoutValidation("Content-Range", $"{chunkStart}-{chunkStart + bytesRead - 1}"));
+
+            HttpResponseMessage? patchResponse = null;
+            for (int retry = 0; retry < 3; retry++)
+            {
+                ExceptionDispatchInfo? e = null;
+                try
+                {
+                    patchResponse = await client.PatchAsync(patchUri, content);
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    e = ExceptionDispatchInfo.Capture(ex);
+                }
+
+                e.Throw();
+            }
+
+            if (patchResponse!.StatusCode != HttpStatusCode.Accepted)
+            {
+                string errorMessage = $"Failed to upload blob to {patchUri}; recieved {patchResponse.StatusCode} with detail {await patchResponse.Content.ReadAsStringAsync()}";
+                throw new ApplicationException(errorMessage);
+            }
+
+            if (patchResponse.Headers.Location is { IsAbsoluteUri: true })
+            {
+                x = new UriBuilder(patchResponse.Headers.Location);
+            }
+            else
+            {
+                // if we don't trim the BaseUri and relative Uri of slashes, you can get invalid urls.
+                // Uri constructor does this on our behalf.
+                x = new UriBuilder(new Uri(BaseUri, patchResponse.Headers.Location?.OriginalString ?? ""));
+            }
+
+            patchUri = x.Uri;
+
+            chunkCount += 1;
+            chunkStart += bytesRead;
+        }
+
+        // PUT with digest to finalize
+        x.Query += $"&digest={Uri.EscapeDataString(digest)}";
+
+        putUri = x.Uri;
+
+        HttpResponseMessage finalizeResponse = await client.PutAsync(putUri, content: null);
+
+        if (finalizeResponse.StatusCode != HttpStatusCode.Created)
+        {
+            string errorMessage = $"Failed to finalize upload to {putUri}; recieved {finalizeResponse.StatusCode} with detail {await finalizeResponse.Content.ReadAsStringAsync()}";
+            throw new ApplicationException(errorMessage);
+        }
     }
 
     private readonly async Task<bool> BlobAlreadyUploaded(string name, string digest, HttpClient client)

--- a/Microsoft.NET.Build.Containers/Registry.cs
+++ b/Microsoft.NET.Build.Containers/Registry.cs
@@ -155,17 +155,9 @@ public record struct Registry(Uri BaseUri)
             ByteArrayContent content = new (chunkBackingStore, offset: 0, count: bytesRead);
             content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
             content.Headers.ContentLength = bytesRead;
-            //HttpResponseMessage putResponse = await client.PutAsync(putUri, content);
-
-            //string resp = await putResponse.Content.ReadAsStringAsync();
-
-            //putResponse.EnsureSuccessStatusCode();
-
-            // Chunked upload
-            //content.Headers.ContentRange = new(from:0, to: contents.Length - 1);
 
             // manual because ACR throws an error with the .NET type {"Range":"bytes 0-84521/*","Reason":"the Content-Range header format is invalid"}
-            //content.Headers.Add("Content-Range", $"0-{contents.Length - 1}");
+            //    content.Headers.Add("Content-Range", $"0-{contents.Length - 1}");
             Debug.Assert(content.Headers.TryAddWithoutValidation("Content-Range", $"{chunkStart}-{chunkStart + bytesRead - 1}"));
 
             HttpResponseMessage? patchResponse = null;

--- a/containerize/Properties/launchSettings.json
+++ b/containerize/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "containerize": {
       "commandName": "Project",
-      "commandLineArgs": "\"S:\\play\\container-package-test\\obj\\Release\\net7.0\\PubTmp\\Out\" --baseregistry mcr.microsoft.com --baseimagename dotnet/aspnet --baseimagetag 7.0 --outputregistry rainercontainer.azurecr.io --imagename container-package-test --workingdirectory /app --entrypoint /app/container-package-test.exe --labels org.opencontainers.image.created=2022-10-27T14:17:19.9046559Z --imagetags latest --ports 80/tcp --environmentvariables ASPNETCORE_URLS=http://+:80 \r\n"
+      "commandLineArgs": "\"S:\\play\\container-package-test\\obj\\Release\\net7.0\\PubTmp\\Out\" --baseregistry mcr.microsoft.com --baseimagename dotnet/aspnet --baseimagetag 7.0 --outputregistry ghcr.io --imagename baronfel/container-package-test --workingdirectory /app --entrypoint /app/container-package-test.exe --labels org.opencontainers.image.created=2022-10-27T14:17:19.9046559Z --imagetags latest --ports 80/tcp --environmentvariables ASPNETCORE_URLS=http://+:80 \r\n"
     }
   }
 }


### PR DESCRIPTION
This + retry seems to get uploads pretty reliable for ghcr.io and
azurecr.io, at least in my testing.
