### PR TITLE
Fix issues pushing images to Amazon ECR

### DIFF
--- a/Microsoft.NET.Build.Containers/AmazonECRMessageHandler.cs
+++ b/Microsoft.NET.Build.Containers/AmazonECRMessageHandler.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.NET.Build.Containers;
+
+/// <summary>
+/// A delegating handler that handles the special error handling needed for Amazon ECR.
+/// 
+/// When pushing images to ECR if the target container repository does not exist ECR ends
+/// the connection causing an IOException with a generic "The response ended prematurely."
+/// error message. The handler catches the generic error and provides a more informed error
+/// message to let the user know they need to create the repository.
+/// </summary>
+public class AmazonECRMessageHandler : DelegatingHandler
+{
+    public AmazonECRMessageHandler(HttpMessageHandler innerHandler) : base(innerHandler) { }
+
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+        catch (HttpRequestException e) when (e.InnerException is IOException ioe && ioe.Message.Equals("The response ended prematurely.", StringComparison.OrdinalIgnoreCase))
+        {
+            var message = "Request to Amazon Elastic Container Registry failed prematurely. This is often caused when the target repository does not exist in the registry.";
+            throw new ContainerHttpException(message, request.RequestUri?.ToString(), null);
+        }
+        catch
+        {
+            throw;
+        }
+    }
+}

--- a/Microsoft.NET.Build.Containers/Registry.cs
+++ b/Microsoft.NET.Build.Containers/Registry.cs
@@ -29,10 +29,13 @@ public struct Registry
     }
 
     /// <summary>
-    /// The max chunk size for patch blob uploads. By default the size is 64 KB.
-    /// Amazon Elasic Container Registry (ECR) requires patch chunk size to be 5 MB except for the last chunk.
+    /// The max chunk size for patch blob uploads. By default the size is 5 MB.
     /// </summary>
-    public readonly int MaxChunkSizeBytes => IsAmazonECRRegistry ? 5248080 : 1024 * 64;
+    /// <remarks>
+    /// 5 MB is chosen because it's the limit that works with all registries we tested - 
+    /// notably Amazon Elastic Container Registry requires 5MB chunks for all but the last chunk.
+    /// </remarks>
+    public readonly int MaxChunkSizeBytes => 5 * 1024 * 1024;
 
     /// <summary>
     /// Check to see if the registry is for Amazon Elastic Container Registry (ECR).

--- a/Microsoft.NET.Build.Containers/Registry.cs
+++ b/Microsoft.NET.Build.Containers/Registry.cs
@@ -19,8 +19,8 @@ public struct Registry
     private const string DockerManifestV2 = "application/vnd.docker.distribution.manifest.v2+json";
     private const string DockerContainerV1 = "application/vnd.docker.container.image.v1+json";
 
-    private Uri BaseUri { get; init; }
-    private string RegistryName => BaseUri.Host;
+    private readonly Uri BaseUri { get; init; }
+    private readonly string RegistryName => BaseUri.Host;
 
     public Registry(Uri baseUri)
     {
@@ -250,9 +250,9 @@ public struct Registry
         return false;
     }
 
-    private HttpClient _client;
+    private readonly HttpClient _client;
 
-    private HttpClient GetClient()
+    private readonly HttpClient GetClient()
     {
         return _client;
     }

--- a/Test.Microsoft.NET.Build.Containers.Filesystem/RegistryTests.cs
+++ b/Test.Microsoft.NET.Build.Containers.Filesystem/RegistryTests.cs
@@ -19,4 +19,19 @@ public class RegistryTests
 
         Assert.IsNotNull(downloadedImage);
     }
+
+    [DataRow("public.ecr.aws", true)]
+    [DataRow("123412341234.dkr.ecr.us-west-2.amazonaws.com", true)]
+    [DataRow("123412341234.dkr.ecr-fips.us-west-2.amazonaws.com", true)]
+    [DataRow("notvalid.dkr.ecr.us-west-2.amazonaws.com", false)]
+    [DataRow("1111.dkr.ecr.us-west-2.amazonaws.com", false)]
+    [DataRow("mcr.microsoft.com", false)]
+    [DataRow("localhost", false)]
+    [DataRow("hub", false)]
+    [TestMethod]
+    public void CheckIfAmazonECR(string registryName, bool isECR)
+    {
+        Registry registry = new Registry(ContainerHelpers.TryExpandRegistryToUri(registryName));
+        Assert.AreEqual(isECR, registry.IsAmazonECRRegistry);
+    }
 }


### PR DESCRIPTION
*Note: I'm on the AWS .NET SDK team not the ECR team. I did some group debugging with the ECR team to understand the failures with this tooling pushing to ECR.*

This PR address the idiosyncrasy when pushing images to ECR.

* If the repository being pushed does not exist ECR abruptly ends the request. I believe that is why in the [RegistryAuthentication.md](https://github.com/dotnet/sdk-container-builds/blob/main/docs/RegistryAuthentication.md#known-unsupported-registries) says the upload was cancelled for unknown reasons. I added special ECR error logic to look for the abrupt end to the request and inform the user they probably haven't created the repository yet.
* When doing the patch chunk uploads of the parts ECR returns back status code 201 (Created) instead of the standard 202 (Accepted). I know this is non standard but at this point if ECR changed the status code that would be a breaking change.
* The chunk size needs to be a minimum of 5 MB except for the last chunk. This PR changes the buffer size to 5 MB when pushing to ECR. Not sure if the original 64 KB had a specific meaning but the logic could be simplified by always using 5 MB buffer size.

I also found that parallelizing uploading all of the layers at the same time especially with the 5 MB buffer size caused to many socket retries and ultimately failures. I changed the code for ECR to upload the layers serially. Probably more should be done there in general to better handle throttling and error reporting since currently a messy AggregateException is thrown up the chain but wanted to get feedback before doing anything more in that space.


![DotnetECRPublish](https://user-images.githubusercontent.com/1653751/210845582-dd546ae5-431e-408f-a8fd-723377910d8f.gif)
