### PR TITLE
Remove customizations for ASP.NET Core applications' ContainerEnvironmentVariables and ContainerPorts

### DIFF
--- a/docs/ContainerCustomization.md
+++ b/docs/ContainerCustomization.md
@@ -174,15 +174,6 @@ ContainerEntrypointArg items have one property:
 </ItemGroup>
 ```
 
-## ASP.NET Core customizations
-
-ASP.NET Core applications have certain defaults that are set to make containers more 'plug and play'.
-
-* A ContainerPort item is set to expose TCP port 80
-* The ASPNETCORE_URLS environment variable is set to `http://+:80` to match that port value.
-
-Both of these will be skipped if a custom value is set.
-
 ## Default container labels
 
 Labels are often used to provide consistent metadata on container images. This package provides some default labels to encourage better maintainability of the generated images.

--- a/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -80,14 +80,6 @@
             <ContainerLabel Include="org.opencontainers.image.created" Value="$([System.DateTime]::UtcNow.ToString('o'))" />
         </ItemGroup>
 
-        <!-- Asp.NET defaults -->
-        <ItemGroup Label="ASP.NET port forwarding" Condition="'$(_IsAspNet)' == 'true'">
-            <ContainerPort Include="80" Type="tcp" Condition="@(ContainerPort->WithMetadataValue('Identity', '80')->AnyHaveMetadataValue('Type', 'tcp')) == ''" />
-
-            <ContainerEnvironmentVariable Include="ASPNETCORE_URLS" Value="http://+:80"
-                                                                    Condition="@(ContainerEnvironmentVariable->WithMetadataValue('Identity', 'ASPNETCORE_URLS')) == ''"/>
-        </ItemGroup>
-
         <ParseContainerProperties FullyQualifiedBaseImageName="$(ContainerBaseImage)"
                                   ContainerRegistry="$(ContainerRegistry)"
                                   ContainerImageName="$(ContainerImageName)"


### PR DESCRIPTION
Closes #148
Closes #165

Base images typically set ASPNETCORE_URLS to relevant port values, so we don't need to try to detect and override that ourselves.