### PR TITLE
Use more conservative upload size

### DIFF
--- a/Microsoft.NET.Build.Containers/Registry.cs
+++ b/Microsoft.NET.Build.Containers/Registry.cs
@@ -29,13 +29,12 @@ public struct Registry
     }
 
     /// <summary>
-    /// The max chunk size for patch blob uploads. By default the size is 5 MB.
+    /// The max chunk size for patch blob uploads.
     /// </summary>
     /// <remarks>
-    /// 5 MB is chosen because it's the limit that works with all registries we tested - 
-    /// notably Amazon Elastic Container Registry requires 5MB chunks for all but the last chunk.
+    /// This varies by registry target, for example Amazon Elastic Container Registry requires 5MB chunks for all but the last chunk.
     /// </remarks>
-    public readonly int MaxChunkSizeBytes => 5248080; //5 * 1024 * 1024;
+    public readonly int MaxChunkSizeBytes => IsAmazonECRRegistry ? 5248080 : 1024 * 64;
 
     /// <summary>
     /// Check to see if the registry is for Amazon Elastic Container Registry (ECR).

--- a/Microsoft.NET.Build.Containers/Registry.cs
+++ b/Microsoft.NET.Build.Containers/Registry.cs
@@ -35,7 +35,7 @@ public struct Registry
     /// 5 MB is chosen because it's the limit that works with all registries we tested - 
     /// notably Amazon Elastic Container Registry requires 5MB chunks for all but the last chunk.
     /// </remarks>
-    public readonly int MaxChunkSizeBytes => 5 * 1024 * 1024;
+    public readonly int MaxChunkSizeBytes => 5248080; //5 * 1024 * 1024;
 
     /// <summary>
     /// Check to see if the registry is for Amazon Elastic Container Registry (ECR).


### PR DESCRIPTION
This failed testing on baronfel/sdk-container-builds, but fixing the math made it work again.