### PR TITLE
Fix environment variable name validation

### DIFF
--- a/Microsoft.NET.Build.Containers/ContainerHelpers.cs
+++ b/Microsoft.NET.Build.Containers/ContainerHelpers.cs
@@ -24,7 +24,10 @@ public static class ContainerHelpers
     
     public const string HostObjectPass = "SDK_CONTAINER_REGISTRY_PWORD";
 
-    private static Regex envVarRegex = new Regex(@"^[a-zA-Z_]+$");
+    /// <summary>
+    /// Matches an environment variable name - must start with a letter or underscore, and can only contain letters, numbers, and underscores.
+    /// </summary>
+    private static Regex envVarRegex = new Regex(@"^[a-zA-Z_]{1,}[a-zA-Z0-9_]*$");
 
     /// <summary>
     /// DefaultRegistry is the canonical representation of something that lives in the local docker daemon. It's used as the inferred registry for repositories

--- a/Test.Microsoft.NET.Build.Containers/ContainerHelpersTests.cs
+++ b/Test.Microsoft.NET.Build.Containers/ContainerHelpersTests.cs
@@ -97,4 +97,18 @@ public class ContainerHelpersTests
             Assert.AreEqual(expectedError, errors);
         }
     }
+
+    [TestMethod]
+    [DataRow("FOO", true)]
+    [DataRow("foo_bar", true)]
+    [DataRow("foo-bar", false)]
+    [DataRow("foo.bar", false)]
+    [DataRow("foo bar", false)]
+    [DataRow("1_NAME", false)]
+    [DataRow("ASPNETCORE_URLS", true)]
+    [DataRow("ASPNETCORE_URLS2", true)]
+    public void CanRecognizeEnvironmentVariableNames(string envVarName, bool isValid) {
+        var success = ContainerHelpers.IsValidEnvironmentVariable(envVarName);
+        Assert.AreEqual(isValid, success, $"Expected {envVarName} to be {(isValid ? "valid" : "invalid")}");
+    }
 }


### PR DESCRIPTION
Closes #290

Changes the validation regex to be 'alpha or underscore character, followed by zero or more alphanumeric or underscore characters', per the Posix spec section 8.1, replicated below

> These strings have the form name=value; names shall not contain the character '='. For values to be portable across systems conforming to POSIX.1-2017, the value shall be composed of characters from the portable character set (except NUL and as indicated below). There is no meaning associated with the order of strings in the environment. If more than one string in an environment of a process has the same name, the consequences are undefined.

> Environment variable names used by the utilities in the Shell and Utilities volume of POSIX.1-2017 consist solely of uppercase letters, digits, and the <underscore> ( '_' ) from the characters defined in [Portable Character Set](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap06.html#tagtcjh_3) and do not begin with a digit. Other characters may be permitted by an implementation; applications shall tolerate the presence of such names. Uppercase and lowercase letters shall retain their unique identities and shall not be folded together. The name space of environment variable names containing lowercase letters is reserved for applications. Applications can define any environment variables with names from this name space without modifying the behavior of the standard utilities.

We technically should allow more characters than this (the '(except NUL and as indicated below)' portion), but the convention is _very clearly_ laid out in the second paragraph.