### PR TITLE
make outputRegistry optional in containerize.exe as well

### DIFF
--- a/Microsoft.NET.Build.Containers/ContainerBuilder.cs
+++ b/Microsoft.NET.Build.Containers/ContainerBuilder.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 public static class ContainerBuilder
 {
-    public static async Task Containerize(DirectoryInfo folder, string workingDir, string registryName, string baseName, string baseTag, string[] entrypoint, string[] entrypointArgs, string imageName, string[] imageTags, string outputRegistry, string[] labels, Port[] exposedPorts, string[] envVars)
+    public static async Task Containerize(DirectoryInfo folder, string workingDir, string registryName, string baseName, string baseTag, string[] entrypoint, string[] entrypointArgs, string imageName, string[] imageTags, string? outputRegistry, string[] labels, Port[] exposedPorts, string[] envVars)
     {
         var isDockerPull = String.IsNullOrEmpty(registryName);
         if (isDockerPull) {
@@ -30,7 +30,7 @@ public static class ContainerBuilder
         img.SetEntrypoint(entrypoint, entrypointArgs);
 
         var isDockerPush = String.IsNullOrEmpty(outputRegistry);
-        Registry? outputReg = isDockerPush ? null : new Registry(ContainerHelpers.TryExpandRegistryToUri(outputRegistry));
+        Registry? outputReg = isDockerPush ? null : new Registry(ContainerHelpers.TryExpandRegistryToUri(outputRegistry!));
 
         foreach (var label in labels)
         {

--- a/Microsoft.NET.Build.Containers/CreateNewImageToolTask.cs
+++ b/Microsoft.NET.Build.Containers/CreateNewImageToolTask.cs
@@ -75,7 +75,7 @@ public partial class CreateNewImage : ToolTask
                " --baseregistry " + BaseRegistry +
                " --baseimagename " + BaseImageName +
                " --baseimagetag " + BaseImageTag +
-               " --outputregistry " + OutputRegistry +
+               (OutputRegistry is not null ? " --outputregistry " + OutputRegistry : "") +
                " --imagename " + ImageName +
                " --workingdirectory " + WorkingDirectory +
                (Entrypoint.Length > 0 ? " --entrypoint " + String.Join(" ", Entrypoint.Select((i) => i.ItemSpec)) : "") +

--- a/containerize/Program.cs
+++ b/containerize/Program.cs
@@ -32,7 +32,7 @@ var outputRegistryOpt = new Option<string>(
     name: "--outputregistry",
     description: "The registry to push to.")
 {
-    IsRequired = true
+    IsRequired = false
 };
 
 var imageNameOpt = new Option<string>(
@@ -175,7 +175,7 @@ root.SetHandler(async (context) =>
     string _baseReg = context.ParseResult.GetValueForOption(baseRegistryOpt) ?? "";
     string _baseName = context.ParseResult.GetValueForOption(baseImageNameOpt) ?? "";
     string _baseTag = context.ParseResult.GetValueForOption(baseImageTagOpt) ?? "";
-    string _outputReg = context.ParseResult.GetValueForOption(outputRegistryOpt) ?? "";
+    string? _outputReg = context.ParseResult.GetValueForOption(outputRegistryOpt);
     string _name = context.ParseResult.GetValueForOption(imageNameOpt) ?? "";
     string[] _tags = context.ParseResult.GetValueForOption(imageTagsOpt) ?? Array.Empty<string>();
     string _workingDir = context.ParseResult.GetValueForOption(workingDirectoryOpt) ?? "";


### PR DESCRIPTION
Closes #297 

The parameter was required, but we weren't covering that case when a) constructing the CLI args in the ToolTask, and b) CLI parsing