### PR TITLE
Fill in conventional labels from existing project metadata

### DIFF
--- a/Microsoft.NET.Build.Containers/KnownStrings.cs
+++ b/Microsoft.NET.Build.Containers/KnownStrings.cs
@@ -22,6 +22,8 @@ public static class KnownStrings
         public static string ContainerBaseRegistry = nameof(ContainerBaseRegistry);
         public static string ContainerBaseName = nameof(ContainerBaseName);
         public static string ContainerBaseTag = nameof(ContainerBaseTag);
+
+        public static string ContainerGenerateLabels = nameof(ContainerGenerateLabels);
     }
 
     public static class ErrorCodes

--- a/docs/ContainerCustomization.md
+++ b/docs/ContainerCustomization.md
@@ -193,6 +193,22 @@ ContainerEntrypointArg items have one property:
 
 ## Default container labels
 
-Labels are often used to provide consistent metadata on container images. This package provides some default labels to encourage better maintainability of the generated images.
+Labels are often used to provide consistent metadata on container images. This package provides some default labels to encourage better maintainability of the generated images, drawn from the set defined as part of the [OCI Image specification](https://github.com/opencontainers/image-spec/blob/main/annotations.md). Where possible, we use the values of common [NuGet Project Properties](https://learn.microsoft.com/en-us/nuget/reference/msbuild-targets#pack-target) as defaults for these annotations, though we also provide more customizable 
 
-* `org.opencontainers.image.created` is set to the ISO 8601 format of the current UTC DateTime
+| Annotation | Default Value | Dedicated Property Name | Fallback Property Name | Enabled Property Name | Notes |
+| - | - | - | - | - | - |
+| `org.opencontainers.image.created` and `org.opencontainers.artifact.created` | the [RFC 3339](https://tools.ietf.org/html/rfc3339#section-5.6) format of the current UTC DateTime |  |  | `ContainerGenerateLabelsImageCreated` |  |
+|`org.opencontainers.artifact.description` and `org.opencontainers.image.description` | | `ContainerDescription` | `Description` | `ContainerGenerateLabelsImageDescription` | |
+| `org.opencontainers.image.authors` | | `ContainerAuthors`| `Authors` | `ContainerGenerateLabelsImageAuthors` | |
+| `org.opencontainers.image.url` | | `ContainerInformationUrl` | `PackageProjectUrl` | `ContainerGenerateLabelsImageUrl` | |
+| `org.opencontainers.image.documentation` | | `ContainerDocumentationUrl` | `PackageProjectUrl` | `ContainerGenerateLabelsImageDocumentation` | |
+| `org.opencontainers.image.version` | | `ContainerVersion` | `PackageVersion` | `ContainerGenerateLabelsImageVersion` | |
+| `org.opencontainers.image.vendor` | | `ContainerVendor` | | `ContainerGenerateLabelsImageVendor` | |
+| `org.opencontainers.image.licenses` | | `ContainerLicenseExpression` | `PackageLicenseExpression` | `ContainerGenerateLabelsImageLicenses` | |
+| `org.opencontainers.image.title` | | `ContainerTitle` | `Title` | `ContainerGenerateLabelsImageTitle` | |
+| `org.opencontainers.image.base.name` | | `ContainerBaseImage` | | `ContainerGenerateLabelsImageBaseName` | |
+| `org.opencontainers.image.source` | | `PrivateRepositoryUrl` | | `ContainerGenerateLabelsImageSource` | Only written if `PublishRepositoryUrl` is `true`. Also relies on Sourcelink infrastructure being part of the build. |
+| `org.opencontainers.image.revision` | | `SourceRevisionId` | | `ContainerGenerateLabelsImageRevision` | Only written if `PublishRepositoryUrl` is `true`. Also relies on Sourcelink infrastructure being part of the build. |
+
+> **Note**
+> You can disable all label generation by setting `ContainerGenerateLabels` to `false` in your project file.

--- a/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -107,17 +107,28 @@
             <ContainerGenerateLabelsImageBaseName Condition="'$(ContainerGenerateLabelsImageBaseName)' == ''">true</ContainerGenerateLabelsImageBaseName>
         </PropertyGroup>
 
+        <PropertyGroup Label="Defaults for Container Labels">
+            <ContainerDescription Condition="'$(ContainerDescription)' == '' and '$(Description)' != ''">$(Description)</ContainerDescription>
+            <ContainerAuthors Condition="'$(ContainerAuthors)' == '' and '$(Authors)' != ''">$(Authors)</ContainerAuthors>
+            <ContainerInformationUrl Condition="'$(ContainerInformationUrl)' == '' and '$(PackageProjectUrl)' != ''">$(PackageProjectUrl)</ContainerInformationUrl>
+            <ContainerDocumentationUrl Condition="'$(ContainerDocumentationUrl)' == '' and '$(PackageProjectUrl)' != ''">$(PackageProjectUrl)</ContainerDocumentationUrl>
+            <ContainerVersion Condition="'$(ContainerVersion)' == '' and '$(PackageVersion)' != ''">$(PackageVersion)</ContainerVersion>
+            <ContainerVendor Condition="'$(ContainerVendor)' == '' and '$(PackageOwners)' != ''">$(PackageOwners)</ContainerVendor>
+            <ContainerLicenseExpression Condition="'$(ContainerLicenseExpression)' == '' and '$(PackageLicenseExpression)' != ''">$(PackageLicenseExpression)</ContainerLicenseExpression>
+            <ContainerTitle Condition="'$(ContainerTitle)' == '' and '$(Title)' != ''">$(Title)</ContainerTitle>
+        </PropertyGroup>
+
         <!-- Labels generated from descriptions from the spec at https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys -->
         <ItemGroup Label="Conventional Label assignment" Condition="'$(ContainerGenerateLabels)' == 'true'">
             <ContainerLabel Condition="'$(ContainerGenerateLabelsImageCreated)' == 'true'" Include="org.opencontainers.image.created;org.opencontainers.artifact.created" Value="$([System.DateTime]::UtcNow.ToString('o'))" />
-            <ContainerLabel Condition="'$(ContainerGenerateLabelsImageDescription)' == 'true' and '$(Description)' != ''" Include="org.opencontainers.artifact.description;org.opencontainers.image.description" Value="$(Description)" />
-            <ContainerLabel Condition="'$(ContainerGenerateLabelsImageAuthors)' == 'true' and '$(Authors)' != ''" Include="org.opencontainers.image.authors" Value="$(Authors)" />
-            <ContainerLabel Condition="'$(ContainerGenerateLabelsImageUrl)' == 'true' and '$(PackageProjectUrl)' != ''" Include="org.opencontainers.image.url" Value="$(PackageProjectUrl)" />
-            <ContainerLabel Condition="'$(ContainerGenerateLabelsImageDocumentation)' == 'true' and '$(PackageDocumentationUrl)' != ''" Include="org.opencontainers.image.documentation" Value="$(PackageDocumentationUrl)" />
-            <ContainerLabel Condition="'$(ContainerGenerateLabelsImageVersion)' == 'true' and '$(PackageVersion)' != ''" Include="org.opencontainers.image.version" Value="$(PackageVersion)" />
-            <ContainerLabel Condition="'$(ContainerGenerateLabelsImageVendor)' == 'true' and '$(PackageOwners)' != ''" Include="org.opencontainers.image.vendor" Value="$(PackageOwners)" />
-            <ContainerLabel Condition="'$(ContainerGenerateLabelsImageLicenses)' == 'true' and '$(PackageLicenseExpression)' != ''" Include="org.opencontainers.image.licenses" Value="$(PackageLicenseExpression)" />
-            <ContainerLabel Condition="'$(ContainerGenerateLabelsImageTitle)' == 'true' and '$(Title)' != ''" Include="org.opencontainers.image.title" Value="$(Title)" />
+            <ContainerLabel Condition="'$(ContainerGenerateLabelsImageDescription)' == 'true' and '$(ContainerDescription)' != ''" Include="org.opencontainers.artifact.description;org.opencontainers.image.description" Value="$(ContainerDescription)" />
+            <ContainerLabel Condition="'$(ContainerGenerateLabelsImageAuthors)' == 'true' and '$(ContainerAuthors)' != ''" Include="org.opencontainers.image.authors" Value="$(ContainerAuthors)" />
+            <ContainerLabel Condition="'$(ContainerGenerateLabelsImageUrl)' == 'true' and '$(ContainerInformationUrl)' != ''" Include="org.opencontainers.image.url" Value="$(ContainerInformationUrl)" />
+            <ContainerLabel Condition="'$(ContainerGenerateLabelsImageDocumentation)' == 'true' and '$(ContainerDocumentationUrl)' != ''" Include="org.opencontainers.image.documentation" Value="$(ContainerDocumentationUrl)" />
+            <ContainerLabel Condition="'$(ContainerGenerateLabelsImageVersion)' == 'true' and '$(ContainerVersion)' != ''" Include="org.opencontainers.image.version" Value="$(ContainerVersion)" />
+            <ContainerLabel Condition="'$(ContainerGenerateLabelsImageVendor)' == 'true' and '$(ContainerVendor)' != ''" Include="org.opencontainers.image.vendor" Value="$(ContainerVendor)" />
+            <ContainerLabel Condition="'$(ContainerGenerateLabelsImageLicenses)' == 'true' and '$(ContainerLicenseExpression)' != ''" Include="org.opencontainers.image.licenses" Value="$(ContainerLicenseExpression)" />
+            <ContainerLabel Condition="'$(ContainerGenerateLabelsImageTitle)' == 'true' and '$(ContainerTitle)' != ''" Include="org.opencontainers.image.title" Value="$(ContainerTitle)" />
             <!-- Need to compute digests, not just names, before we can light this up. This suggests we need a task where all of the 'read' steps are done. -->
             <!-- <ContainerLabel Condition="'$(ContainerGenerateLabelsImageBaseDigest)' == 'true' and '$(ContainerBaseImageDigest)' != ''" Include="org.opencontainers.image.base.digest" Value="$(ContainerBaseImageDigest)" /> -->
             <ContainerLabel Condition="'$(ContainerGenerateLabelsImageBaseName)' == 'true' and '$(ContainerBaseImage)' != ''" Include="org.opencontainers.image.base.name" Value="$(ContainerBaseImage)" />

--- a/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -90,6 +90,23 @@
             <Output TaskParameter="NewContainerEnvironmentVariables" ItemName="ContainerEnvironmentVariables" />
         </ParseContainerProperties>
 
+        <PropertyGroup>
+            <ContainerGenerateLabels Condition="'$(ContainerGenerateLabels)' == ''">true</ContainerGenerateLabels>
+            <ContainerGenerateLabelsImageCreated Condition="'$(ContainerGenerateLabelsImageCreated)' == ''">true</ContainerGenerateLabelsImageCreated>
+            <ContainerGenerateLabelsImageDescription Condition="'$(ContainerGenerateLabelsImageDescription)' == ''">true</ContainerGenerateLabelsImageDescription>
+            <ContainerGenerateLabelsImageAuthors Condition="'$(ContainerGenerateLabelsImageAuthors)' == ''">true</ContainerGenerateLabelsImageAuthors>
+            <ContainerGenerateLabelsImageUrl Condition="'$(ContainerGenerateLabelsImageUrl)' == ''">true</ContainerGenerateLabelsImageUrl>
+            <ContainerGenerateLabelsImageDocumentation Condition="'$(ContainerGenerateLabelsImageDocumentation)' == ''">true</ContainerGenerateLabelsImageDocumentation>
+            <ContainerGenerateLabelsImageSource Condition="'$(ContainerGenerateLabelsImageSource)' == ''">true</ContainerGenerateLabelsImageSource>
+            <ContainerGenerateLabelsImageVersion Condition="'$(ContainerGenerateLabelsImageVersion)' == ''">true</ContainerGenerateLabelsImageVersion>
+            <ContainerGenerateLabelsImageRevision Condition="'$(ContainerGenerateLabelsImageRevision)' == ''">true</ContainerGenerateLabelsImageRevision>
+            <ContainerGenerateLabelsImageVendor Condition="'$(ContainerGenerateLabelsImageVendor)' == ''">true</ContainerGenerateLabelsImageVendor>
+            <ContainerGenerateLabelsImageLicenses Condition="'$(ContainerGenerateLabelsImageLicenses)' == ''">true</ContainerGenerateLabelsImageLicenses>
+            <ContainerGenerateLabelsImageTitle Condition="'$(ContainerGenerateLabelsImageTitle)' == ''">true</ContainerGenerateLabelsImageTitle>
+            <ContainerGenerateLabelsImageBaseDigest Condition="'$(ContainerGenerateLabelsImageBaseDigest)' == ''">true</ContainerGenerateLabelsImageBaseDigest>
+            <ContainerGenerateLabelsImageBaseName Condition="'$(ContainerGenerateLabelsImageBaseName)' == ''">true</ContainerGenerateLabelsImageBaseName>
+        </PropertyGroup>
+
         <!-- Labels generated from descriptions from the spec at https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys -->
         <ItemGroup Label="Conventional Label assignment" Condition="'$(ContainerGenerateLabels)' == 'true'">
             <ContainerLabel Condition="'$(ContainerGenerateLabelsImageCreated)' == 'true'" Include="org.opencontainers.image.created;org.opencontainers.artifact.created" Value="$([System.DateTime]::UtcNow.ToString('o'))" />
@@ -97,15 +114,20 @@
             <ContainerLabel Condition="'$(ContainerGenerateLabelsImageAuthors)' == 'true' and '$(Authors)' != ''" Include="org.opencontainers.image.authors" Value="$(Authors)" />
             <ContainerLabel Condition="'$(ContainerGenerateLabelsImageUrl)' == 'true' and '$(PackageProjectUrl)' != ''" Include="org.opencontainers.image.url" Value="$(PackageProjectUrl)" />
             <ContainerLabel Condition="'$(ContainerGenerateLabelsImageDocumentation)' == 'true' and '$(PackageDocumentationUrl)' != ''" Include="org.opencontainers.image.documentation" Value="$(PackageDocumentationUrl)" />
-            <ContainerLabel Condition="'$(ContainerGenerateLabelsImageSource)' == 'true' and '$(RepositoryUrl)' != ''" Include="org.opencontainers.image.source" Value="$(RepositoryUrl)" />
             <ContainerLabel Condition="'$(ContainerGenerateLabelsImageVersion)' == 'true' and '$(PackageVersion)' != ''" Include="org.opencontainers.image.version" Value="$(PackageVersion)" />
-            <ContainerLabel Condition="'$(ContainerGenerateLabelsImageRevision)' == 'true' and '$(RepositoryCommit)' != ''" Include="org.opencontainers.image.revision" Value="$(RepositoryCommit)" />
             <ContainerLabel Condition="'$(ContainerGenerateLabelsImageVendor)' == 'true' and '$(PackageOwners)' != ''" Include="org.opencontainers.image.vendor" Value="$(PackageOwners)" />
             <ContainerLabel Condition="'$(ContainerGenerateLabelsImageLicenses)' == 'true' and '$(PackageLicenseExpression)' != ''" Include="org.opencontainers.image.licenses" Value="$(PackageLicenseExpression)" />
             <ContainerLabel Condition="'$(ContainerGenerateLabelsImageTitle)' == 'true' and '$(Title)' != ''" Include="org.opencontainers.image.title" Value="$(Title)" />
             <!-- Need to compute digests, not just names, before we can light this up. This suggests we need a task where all of the 'read' steps are done. -->
-            <!-- <ContainerLabel Condition="'$(ContainerGenerateLabelsBaseDigest)' == 'true' and '$(ContainerBaseImageDigest)' != ''" Include="org.opencontainers.base.digest" Value="$(ContainerBaseImageDigest)" /> -->
+            <!-- <ContainerLabel Condition="'$(ContainerGenerateLabelsImageBaseDigest)' == 'true' and '$(ContainerBaseImageDigest)' != ''" Include="org.opencontainers.image.base.digest" Value="$(ContainerBaseImageDigest)" /> -->
             <ContainerLabel Condition="'$(ContainerGenerateLabelsImageBaseName)' == 'true' and '$(ContainerBaseImage)' != ''" Include="org.opencontainers.image.base.name" Value="$(ContainerBaseImage)" />
+        </ItemGroup>
+
+        <!-- These sourcelink-derived properties are onyl allowed to flow to generated artifacts if `PublishRepositoryUrl` is set as a user signal for opt-in.
+              In addition, the 'nice' property names are currently set by NuGet Pack targets and so we have to use the private/generic names here.  -->
+        <ItemGroup Label="Source control label assignment" Condition="'$(ContainerGenerateLabels)' == 'true' and '$(PublishRepositoryUrl)' == 'true'">
+            <ContainerLabel Condition="'$(ContainerGenerateLabelsImageSource)' == 'true' and '$(PrivateRepositoryUrl)' != ''" Include="org.opencontainers.image.source" Value="$(PrivateRepositoryUrl)" />
+            <ContainerLabel Condition="'$(ContainerGenerateLabelsImageRevision)' == 'true' and '$(SourceRevisionId)' != ''" Include="org.opencontainers.image.revision" Value="$(SourceRevisionId)" />
         </ItemGroup>
     </Target>
 

--- a/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -113,7 +113,6 @@
             <ContainerInformationUrl Condition="'$(ContainerInformationUrl)' == '' and '$(PackageProjectUrl)' != ''">$(PackageProjectUrl)</ContainerInformationUrl>
             <ContainerDocumentationUrl Condition="'$(ContainerDocumentationUrl)' == '' and '$(PackageProjectUrl)' != ''">$(PackageProjectUrl)</ContainerDocumentationUrl>
             <ContainerVersion Condition="'$(ContainerVersion)' == '' and '$(PackageVersion)' != ''">$(PackageVersion)</ContainerVersion>
-            <ContainerVendor Condition="'$(ContainerVendor)' == '' and '$(PackageOwners)' != ''">$(PackageOwners)</ContainerVendor>
             <ContainerLicenseExpression Condition="'$(ContainerLicenseExpression)' == '' and '$(PackageLicenseExpression)' != ''">$(PackageLicenseExpression)</ContainerLicenseExpression>
             <ContainerTitle Condition="'$(ContainerTitle)' == '' and '$(Title)' != ''">$(Title)</ContainerTitle>
         </PropertyGroup>
@@ -134,8 +133,8 @@
             <ContainerLabel Condition="'$(ContainerGenerateLabelsImageBaseName)' == 'true' and '$(ContainerBaseImage)' != ''" Include="org.opencontainers.image.base.name" Value="$(ContainerBaseImage)" />
         </ItemGroup>
 
-        <!-- These sourcelink-derived properties are onyl allowed to flow to generated artifacts if `PublishRepositoryUrl` is set as a user signal for opt-in.
-              In addition, the 'nice' property names are currently set by NuGet Pack targets and so we have to use the private/generic names here.  -->
+        <!-- These sourcelink-derived properties are only allowed to flow to generated artifacts if `PublishRepositoryUrl` is set as a user signal for opt-in.
+             In addition, the 'nice' property names are currently set by NuGet Pack targets and so we have to use the private/generic names here.  -->
         <ItemGroup Label="Source control label assignment" Condition="'$(ContainerGenerateLabels)' == 'true' and '$(PublishRepositoryUrl)' == 'true'">
             <ContainerLabel Condition="'$(ContainerGenerateLabelsImageSource)' == 'true' and '$(PrivateRepositoryUrl)' != ''" Include="org.opencontainers.image.source" Value="$(PrivateRepositoryUrl)" />
             <ContainerLabel Condition="'$(ContainerGenerateLabelsImageRevision)' == 'true' and '$(SourceRevisionId)' != ''" Include="org.opencontainers.image.revision" Value="$(SourceRevisionId)" />

--- a/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -74,11 +74,6 @@
             <ContainerEntrypoint Condition="'$(ContainerEntrypoint)' == '' and '$(UseAppHost)' == 'true'" Include="$(ContainerWorkingDirectory)/$(AssemblyName)$(_NativeExecutableExtension)" />
         </ItemGroup>
 
-        <ItemGroup Label="Conventional Label assignment">
-            <!-- TODO: This impacts build reproducibility - it should probably be settable/conditioned on a property -->
-            <ContainerLabel Include="org.opencontainers.image.created" Value="$([System.DateTime]::UtcNow.ToString('o'))" />
-        </ItemGroup>
-
         <ParseContainerProperties FullyQualifiedBaseImageName="$(ContainerBaseImage)"
                                   ContainerRegistry="$(ContainerRegistry)"
                                   ContainerImageName="$(ContainerImageName)"
@@ -94,6 +89,24 @@
             <Output TaskParameter="NewContainerTags" ItemName="ContainerImageTags" />
             <Output TaskParameter="NewContainerEnvironmentVariables" ItemName="ContainerEnvironmentVariables" />
         </ParseContainerProperties>
+
+        <!-- Labels generated from descriptions from the spec at https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys -->
+        <ItemGroup Label="Conventional Label assignment" Condition="'$(ContainerGenerateLabels)' == 'true'">
+            <ContainerLabel Condition="'$(ContainerGenerateLabelsImageCreated)' == 'true'" Include="org.opencontainers.image.created;org.opencontainers.artifact.created" Value="$([System.DateTime]::UtcNow.ToString('o'))" />
+            <ContainerLabel Condition="'$(ContainerGenerateLabelsImageDescription)' == 'true' and '$(Description)' != ''" Include="org.opencontainers.artifact.description;org.opencontainers.image.description" Value="$(Description)" />
+            <ContainerLabel Condition="'$(ContainerGenerateLabelsImageAuthors)' == 'true' and '$(Authors)' != ''" Include="org.opencontainers.image.authors" Value="$(Authors)" />
+            <ContainerLabel Condition="'$(ContainerGenerateLabelsImageUrl)' == 'true' and '$(PackageProjectUrl)' != ''" Include="org.opencontainers.image.url" Value="$(PackageProjectUrl)" />
+            <ContainerLabel Condition="'$(ContainerGenerateLabelsImageDocumentation)' == 'true' and '$(PackageDocumentationUrl)' != ''" Include="org.opencontainers.image.documentation" Value="$(PackageDocumentationUrl)" />
+            <ContainerLabel Condition="'$(ContainerGenerateLabelsImageSource)' == 'true' and '$(RepositoryUrl)' != ''" Include="org.opencontainers.image.source" Value="$(RepositoryUrl)" />
+            <ContainerLabel Condition="'$(ContainerGenerateLabelsImageVersion)' == 'true' and '$(PackageVersion)' != ''" Include="org.opencontainers.image.version" Value="$(PackageVersion)" />
+            <ContainerLabel Condition="'$(ContainerGenerateLabelsImageRevision)' == 'true' and '$(RepositoryCommit)' != ''" Include="org.opencontainers.image.revision" Value="$(RepositoryCommit)" />
+            <ContainerLabel Condition="'$(ContainerGenerateLabelsImageVendor)' == 'true' and '$(PackageOwners)' != ''" Include="org.opencontainers.image.vendor" Value="$(PackageOwners)" />
+            <ContainerLabel Condition="'$(ContainerGenerateLabelsImageLicenses)' == 'true' and '$(PackageLicenseExpression)' != ''" Include="org.opencontainers.image.licenses" Value="$(PackageLicenseExpression)" />
+            <ContainerLabel Condition="'$(ContainerGenerateLabelsImageTitle)' == 'true' and '$(Title)' != ''" Include="org.opencontainers.image.title" Value="$(Title)" />
+            <!-- Need to compute digests, not just names, before we can light this up. This suggests we need a task where all of the 'read' steps are done. -->
+            <!-- <ContainerLabel Condition="'$(ContainerGenerateLabelsBaseDigest)' == 'true' and '$(ContainerBaseImageDigest)' != ''" Include="org.opencontainers.base.digest" Value="$(ContainerBaseImageDigest)" /> -->
+            <ContainerLabel Condition="'$(ContainerGenerateLabelsImageBaseName)' == 'true' and '$(ContainerBaseImage)' != ''" Include="org.opencontainers.image.base.name" Value="$(ContainerBaseImage)" />
+        </ItemGroup>
     </Target>
 
     <PropertyGroup>


### PR DESCRIPTION
Closes https://github.com/dotnet/sdk-container-builds/issues/96

This fills in the metada in #96 using project properties. There are conditionals for the entire generation as well as each specific item. The properties are patterned after the NuGet [pack targets](https://learn.microsoft.com/en-us/nuget/reference/msbuild-targets#pack-target) mappings.

The only caveat is that the source control urls aren't flowed through unless the `PublishRepositoryUrl` property is set to true, following guidance from the sourcelink repo.

* [x] add tests for coverage of the new items
* [x] add to existing documentation section on container customization