### PR TITLE
Extract an interface for local daemons, and check for local docker daemon activity.

### DIFF
--- a/Microsoft.NET.Build.Containers/BaseImageNotFoundException.cs
+++ b/Microsoft.NET.Build.Containers/BaseImageNotFoundException.cs
@@ -1,0 +1,6 @@
+namespace Microsoft.NET.Build.Containers;
+public class BaseImageNotFoundException : Exception
+{
+    public BaseImageNotFoundException(string specifiedRuntimeIdentifier, string repositoryName, string reference, IEnumerable<string> supportedRuntimeIdentifiers)
+            : base($"The RuntimeIdentifier '{specifiedRuntimeIdentifier}' is not supported by {repositoryName}:{reference}. The supported RuntimeIdentifiers are {String.Join(",", supportedRuntimeIdentifiers)}") {}
+}

--- a/Microsoft.NET.Build.Containers/BaseImageNotFoundException.cs
+++ b/Microsoft.NET.Build.Containers/BaseImageNotFoundException.cs
@@ -1,4 +1,8 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 namespace Microsoft.NET.Build.Containers;
+
 public class BaseImageNotFoundException : Exception
 {
     public BaseImageNotFoundException(string specifiedRuntimeIdentifier, string repositoryName, string reference, IEnumerable<string> supportedRuntimeIdentifiers)

--- a/Microsoft.NET.Build.Containers/ContainerBuilder.cs
+++ b/Microsoft.NET.Build.Containers/ContainerBuilder.cs
@@ -83,9 +83,9 @@ public static class ContainerBuilder
             }
             else
             {
-                
+
                 var localDaemon = GetLocalDaemon(localContainerDaemon, Console.WriteLine);
-                if (!(await localDaemon.IsAvailable()))
+                if (!(await localDaemon.IsAvailable().ConfigureAwait(false)))
                 {
                     Console.WriteLine("Containerize: error CONTAINER007: The Docker daemon is not available, but pushing to a local daemon was requested. Please start Docker and try again.");
                     Environment.ExitCode = 7;

--- a/Microsoft.NET.Build.Containers/ContainerBuilder.cs
+++ b/Microsoft.NET.Build.Containers/ContainerBuilder.cs
@@ -80,7 +80,7 @@ public static class ContainerBuilder
             }
             else
             {
-                var localDaemon = new LocalDocker();
+                var localDaemon = new LocalDocker(Console.WriteLine);
                 if (!(await localDaemon.IsAvailable())) { 
                     Console.WriteLine("Containerize: error CONTAINER007: The Docker daemon is not available, but pushing to a local daemon was requested. Please start Docker and try again.");
                     Environment.ExitCode = 7;

--- a/Microsoft.NET.Build.Containers/ContainerBuilder.cs
+++ b/Microsoft.NET.Build.Containers/ContainerBuilder.cs
@@ -23,9 +23,6 @@ public static class ContainerBuilder
         var destinationImageReferences = imageTags.Select(t => new ImageReference(isDockerPush ? null : new Registry(ContainerHelpers.TryExpandRegistryToUri(outputRegistry!)), imageName, t));
 
         var img = await baseRegistry.GetImageManifest(baseName, baseTag, containerRuntimeIdentifier, ridGraphPath).ConfigureAwait(false);
-        if (img is null) {
-            throw new ImageNotFoundException($"Could not find image {sourceImageReference} matching RuntimeIdentifier {containerRuntimeIdentifier}");
-        }
 
         img.WorkingDirectory = workingDir;
 

--- a/Microsoft.NET.Build.Containers/ContainerBuilder.cs
+++ b/Microsoft.NET.Build.Containers/ContainerBuilder.cs
@@ -75,20 +75,26 @@ public static class ContainerBuilder
                 catch (Exception e)
                 {
                     Console.WriteLine($"Containerize: error CONTAINER001: Failed to push to output registry: {e}");
-                    Environment.ExitCode = -1;
+                    Environment.ExitCode = 1;
                 }
             }
             else
             {
+                var localDaemon = new LocalDocker();
+                if (!(await localDaemon.IsAvailable())) { 
+                    Console.WriteLine("Containerize: error CONTAINER007: The Docker daemon is not available, but pushing to a local daemon was requested. Please start Docker and try again.");
+                    Environment.ExitCode = 7;
+                    return;
+                }
                 try
                 {
-                    LocalDocker.Load(img, sourceImageReference, destinationImageReference).Wait();
+                    localDaemon.Load(img, sourceImageReference, destinationImageReference).Wait();
                     Console.WriteLine("Containerize: Pushed container '{0}' to Docker daemon", destinationImageReference.RepositoryAndTag);
                 }
                 catch (Exception e)
                 {
                     Console.WriteLine($"Containerize: error CONTAINER001: Failed to push to local docker registry: {e}");
-                    Environment.ExitCode = -1;
+                    Environment.ExitCode = 1;
                 }
             }
         }

--- a/Microsoft.NET.Build.Containers/ContainerBuilder.cs
+++ b/Microsoft.NET.Build.Containers/ContainerBuilder.cs
@@ -14,7 +14,7 @@ public static class ContainerBuilder
     {
         var isDockerPull = String.IsNullOrEmpty(registryName);
         if (isDockerPull) {
-            throw new ArgumentException("Don't know how to pull images from local daemons at the moment");
+            throw new NotSupportedException("Don't know how to pull images from local daemons at the moment");
         }
 
         Registry baseRegistry = new Registry(ContainerHelpers.TryExpandRegistryToUri(registryName));
@@ -24,7 +24,7 @@ public static class ContainerBuilder
 
         var img = await baseRegistry.GetImageManifest(baseName, baseTag, containerRuntimeIdentifier, ridGraphPath).ConfigureAwait(false);
         if (img is null) {
-            throw new ArgumentException($"Could not find image {sourceImageReference} matching RuntimeIdentifier {containerRuntimeIdentifier}");
+            throw new ImageNotFoundException($"Could not find image {sourceImageReference} matching RuntimeIdentifier {containerRuntimeIdentifier}");
         }
 
         img.WorkingDirectory = workingDir;
@@ -74,7 +74,7 @@ public static class ContainerBuilder
                 }
                 catch (Exception e)
                 {
-                    Console.WriteLine($"Containerize: error CONTAINER001: Failed to push to output registry: {e}");
+                    Console.WriteLine($"Containerize: error CONTAINER001: Failed to push to output registry: {e.Message}");
                     Environment.ExitCode = 1;
                 }
             }
@@ -93,7 +93,7 @@ public static class ContainerBuilder
                 }
                 catch (Exception e)
                 {
-                    Console.WriteLine($"Containerize: error CONTAINER001: Failed to push to local docker registry: {e}");
+                    Console.WriteLine($"Containerize: error CONTAINER001: Failed to push to local docker registry: {e.Message}");
                     Environment.ExitCode = 1;
                 }
             }

--- a/Microsoft.NET.Build.Containers/CreateNewImage.Interface.cs
+++ b/Microsoft.NET.Build.Containers/CreateNewImage.Interface.cs
@@ -44,6 +44,12 @@ partial class CreateNewImage
     public string OutputRegistry { get; set; }
 
     /// <summary>
+    /// The kind of local daemon to use, if any.
+    /// </summary>
+    [Required]
+    public string LocalContainerDaemon { get; set; }
+
+    /// <summary>
     /// The name of the output image that will be pushed to the registry.
     /// </summary>
     [Required]
@@ -114,7 +120,6 @@ partial class CreateNewImage
     [Output]
     public string GeneratedContainerConfiguration { get; set; }
 
-
     public CreateNewImage()
     {
         ContainerizeDirectory = "";
@@ -135,6 +140,7 @@ partial class CreateNewImage
         ContainerEnvironmentVariables = Array.Empty<ITaskItem>();
         ContainerRuntimeIdentifier = "";
         RuntimeIdentifierGraphPath = "";
+        LocalContainerDaemon = "";
 
         GeneratedContainerConfiguration = "";
         GeneratedContainerManifest = "";

--- a/Microsoft.NET.Build.Containers/CreateNewImage.cs
+++ b/Microsoft.NET.Build.Containers/CreateNewImage.cs
@@ -3,6 +3,7 @@
 
 using System.Text.Json;
 using Microsoft.Build.Framework;
+using System.Linq;
 
 namespace Microsoft.NET.Build.Containers.Tasks;
 
@@ -68,6 +69,26 @@ public partial class CreateNewImage : Microsoft.Build.Utilities.Task
         }
     }
 
+    private Lazy<Registry?> SourceRegistry
+    {
+        get {
+            if(IsDockerPull) {
+                return new Lazy<Registry?>(() => null);
+            } else {
+                return new Lazy<Registry?>(() => new Registry(ContainerHelpers.TryExpandRegistryToUri(BaseRegistry)));
+            }
+        }
+    }
+
+    private Lazy<Registry?> DestinationRegistry {
+        get {
+            if(IsDockerPush) {
+                return new Lazy<Registry?>(() => null);
+            } else {
+                return new Lazy<Registry?>(() => new Registry(ContainerHelpers.TryExpandRegistryToUri(OutputRegistry)));
+            }
+        }
+    }
     private static void SetEnvironmentVariables(Image img, ITaskItem[] envVars)
     {
         foreach (ITaskItem envVar in envVars)
@@ -77,11 +98,10 @@ public partial class CreateNewImage : Microsoft.Build.Utilities.Task
     }
 
     private Image? GetBaseImage() {
-        if (IsDockerPull) {
-            throw new ArgumentException("Don't know how to pull images from local daemons at the moment");
+        if (SourceRegistry.Value is {} registry) {
+            return registry.GetImageManifest(BaseImageName, BaseImageTag, ContainerRuntimeIdentifier, RuntimeIdentifierGraphPath).Result;
         } else {
-            var reg = new Registry(ContainerHelpers.TryExpandRegistryToUri(BaseRegistry));
-            return reg.GetImageManifest(BaseImageName, BaseImageTag, ContainerRuntimeIdentifier, RuntimeIdentifierGraphPath).Result;
+            throw new ArgumentException("Don't know how to pull images from local daemons at the moment");
         }
     }
 
@@ -96,15 +116,17 @@ public partial class CreateNewImage : Microsoft.Build.Utilities.Task
             Log.LogError("{0} '{1}' does not exist", nameof(PublishDirectory), PublishDirectory);
             return !Log.HasLoggedErrors;
         }
+        ImageReference sourceImageReference = new(SourceRegistry.Value, BaseImageName, BaseImageTag);
+        var destinationImageReferences = ImageTags.Select(t => new ImageReference(DestinationRegistry.Value, ImageName, t));
 
         var image = GetBaseImage();
 
         if (image is null) {
-            Log.LogError($"Couldn't find matching base image for {0}:{1} that matches RuntimeIdentifier {2}", BaseImageName, BaseImageTag, ContainerRuntimeIdentifier);
+            Log.LogError($"Couldn't find matching base image for {0} that matches RuntimeIdentifier {1}", sourceImageReference.RepositoryAndTag, ContainerRuntimeIdentifier);
             return !Log.HasLoggedErrors;
         }
 
-        SafeLog("Building image '{0}' with tags {1} on top of base image {2}/{3}:{4}", ImageName, String.Join(",", ImageTags), BaseRegistry, BaseImageName, BaseImageTag);
+        SafeLog("Building image '{0}' with tags {1} on top of base image {2}", ImageName, String.Join(",", ImageTags), sourceImageReference);
 
         Layer newLayer = Layer.FromDirectory(PublishDirectory, WorkingDirectory);
         image.AddLayer(newLayer);
@@ -130,15 +152,15 @@ public partial class CreateNewImage : Microsoft.Build.Utilities.Task
         GeneratedContainerManifest =  JsonSerializer.Serialize(image.manifest);
         GeneratedContainerConfiguration = image.config.ToJsonString();
 
-        Registry? outputReg = IsDockerPush ? null : new Registry(ContainerHelpers.TryExpandRegistryToUri(OutputRegistry));
-        foreach (var tag in ImageTags)
+
+        foreach (var destinationImageReference in destinationImageReferences)
         {
             if (IsDockerPush)
             {
                 try
                 {
-                    LocalDocker.Load(image, ImageName, tag, BaseImageName).Wait();
-                    SafeLog("Pushed container '{0}:{1}' to Docker daemon", ImageName, tag);
+                    LocalDocker.Load(image, sourceImageReference, destinationImageReference).Wait();
+                    SafeLog("Pushed container '{0}' to Docker daemon", destinationImageReference.RepositoryAndTag);
                 }
                 catch (AggregateException ex) when (ex.InnerException is DockerLoadException dle)
                 {
@@ -149,8 +171,8 @@ public partial class CreateNewImage : Microsoft.Build.Utilities.Task
             {
                 try
                 {
-                    outputReg?.Push(image, ImageName, tag, BaseImageName, message => SafeLog(message)).Wait();
-                    SafeLog("Pushed container '{0}:{1}' to registry '{2}'", ImageName, tag, OutputRegistry);
+                    destinationImageReference.Registry?.Push(image, sourceImageReference, destinationImageReference, message => SafeLog(message)).Wait();
+                    SafeLog("Pushed container '{0}' to registry '{2}'", destinationImageReference.RepositoryAndTag, OutputRegistry);
                 }
                 catch (ContainerHttpException e)
                 {

--- a/Microsoft.NET.Build.Containers/CreateNewImage.cs
+++ b/Microsoft.NET.Build.Containers/CreateNewImage.cs
@@ -157,9 +157,14 @@ public partial class CreateNewImage : Microsoft.Build.Utilities.Task
         {
             if (IsDockerPush)
             {
+                var localDaemon = new LocalDocker();
+                if (!localDaemon.IsAvailable().GetAwaiter().GetResult()) { 
+                    Log.LogError("The Docker daemon is not available, but pushing to a local daemon was requested. Please start Docker and try again.");
+                    return false;
+                }
                 try
                 {
-                    LocalDocker.Load(image, sourceImageReference, destinationImageReference).Wait();
+                    localDaemon.Load(image, sourceImageReference, destinationImageReference).Wait();
                     SafeLog("Pushed container '{0}' to Docker daemon", destinationImageReference.RepositoryAndTag);
                 }
                 catch (AggregateException ex) when (ex.InnerException is DockerLoadException dle)

--- a/Microsoft.NET.Build.Containers/CreateNewImage.cs
+++ b/Microsoft.NET.Build.Containers/CreateNewImage.cs
@@ -157,7 +157,7 @@ public partial class CreateNewImage : Microsoft.Build.Utilities.Task
         {
             if (IsDockerPush)
             {
-                var localDaemon = new LocalDocker();
+                var localDaemon = new LocalDocker(msg => Log.LogMessage(msg));
                 if (!localDaemon.IsAvailable().GetAwaiter().GetResult()) { 
                     Log.LogError("The Docker daemon is not available, but pushing to a local daemon was requested. Please start Docker and try again.");
                     return false;

--- a/Microsoft.NET.Build.Containers/CreateNewImageToolTask.cs
+++ b/Microsoft.NET.Build.Containers/CreateNewImageToolTask.cs
@@ -79,6 +79,7 @@ public partial class CreateNewImage : ToolTask
                " --baseimagename " + BaseImageName +
                " --baseimagetag " + BaseImageTag +
                (OutputRegistry is not null ? " --outputregistry " + OutputRegistry : "") +
+               "--localcontainerdaemon " + LocalContainerDaemon +
                " --imagename " + ImageName +
                " --workingdirectory " + WorkingDirectory +
                (Entrypoint.Length > 0 ? " --entrypoint " + String.Join(" ", Entrypoint.Select((i) => i.ItemSpec)) : "") +

--- a/Microsoft.NET.Build.Containers/Image.cs
+++ b/Microsoft.NET.Build.Containers/Image.cs
@@ -13,9 +13,6 @@ public class Image
     public ManifestV2 manifest;
     public JsonNode config;
 
-    public readonly string OriginatingName;
-    internal readonly Registry? originatingRegistry;
-
     internal List<Layer> newLayers = new();
 
     private HashSet<Label> labels;
@@ -24,12 +21,10 @@ public class Image
 
     internal Dictionary<string, string> environmentVariables;
 
-    public Image(ManifestV2 manifest, JsonNode config, string name, Registry? registry)
+    public Image(ManifestV2 manifest, JsonNode config)
     {
         this.manifest = manifest;
         this.config = config;
-        this.OriginatingName = name;
-        this.originatingRegistry = registry;
         // these next values are inherited from the parent image, so we need to seed our new image with them.
         this.labels = ReadLabelsFromConfig(config);
         this.exposedPorts = ReadPortsFromConfig(config);

--- a/Microsoft.NET.Build.Containers/ImageReference.cs
+++ b/Microsoft.NET.Build.Containers/ImageReference.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.NET.Build.Containers;
+
+public readonly record struct ImageReference(Registry? Registry, string Repository, string Tag) {
+    public override string ToString()
+    {
+        if (Registry is {} reg) {
+            return $"{reg.BaseUri.GetComponents(UriComponents.HostAndPort, UriFormat.Unescaped)}/{Repository}:{Tag}";
+        } else {
+            return RepositoryAndTag;
+        }
+    }
+
+    public readonly string RepositoryAndTag => $"{Repository}:{Tag}";
+}

--- a/Microsoft.NET.Build.Containers/ImageReference.cs
+++ b/Microsoft.NET.Build.Containers/ImageReference.cs
@@ -3,6 +3,9 @@
 
 namespace Microsoft.NET.Build.Containers;
 
+/// <summary>
+/// Represents a reference to a Docker image. A reference is made of a registry, a repository (aka the image name) and a tag.
+/// </summary>
 public readonly record struct ImageReference(Registry? Registry, string Repository, string Tag) {
     public override string ToString()
     {
@@ -13,5 +16,8 @@ public readonly record struct ImageReference(Registry? Registry, string Reposito
         }
     }
 
+    /// <summary>
+    /// Returns the repository and tag as a formatted string. Used in cases
+    /// </summary>
     public readonly string RepositoryAndTag => $"{Repository}:{Tag}";
 }

--- a/Microsoft.NET.Build.Containers/LocalDaemons/ILocalDaemon.cs
+++ b/Microsoft.NET.Build.Containers/LocalDaemons/ILocalDaemon.cs
@@ -1,0 +1,8 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.NET.Build.Containers;
+
+public interface ILocalDaemon {
+    public Task Load(Image image, ImageReference reference);
+}

--- a/Microsoft.NET.Build.Containers/LocalDaemons/ILocalDaemon.cs
+++ b/Microsoft.NET.Build.Containers/LocalDaemons/ILocalDaemon.cs
@@ -4,5 +4,6 @@
 namespace Microsoft.NET.Build.Containers;
 
 public interface ILocalDaemon {
-    public Task Load(Image image, ImageReference reference);
+    public Task Load(Image image, ImageReference sourceReference, ImageReference destinationReference);
+    public Task<bool> IsAvailable();
 }

--- a/Microsoft.NET.Build.Containers/LocalDaemons/ILocalDaemon.cs
+++ b/Microsoft.NET.Build.Containers/LocalDaemons/ILocalDaemon.cs
@@ -4,7 +4,7 @@
 namespace Microsoft.NET.Build.Containers;
 
 /// <summary>
-/// Abstracts over the concept of a local container runtime of some kind. Currently this is only modeled by Docker, 
+/// Abstracts over the concept of a local container runtime of some kind. Currently this is only modeled by Docker,
 /// but users have expressed desires for Podman, nerdctl, etc as well so this kind of abstraction makes sense to have.
 /// </summary>
 public interface ILocalDaemon {
@@ -13,9 +13,14 @@ public interface ILocalDaemon {
     /// Loads an image (presumably from a tarball) into the local container runtime.
     /// </summary>
     public Task Load(Image image, ImageReference sourceReference, ImageReference destinationReference);
-    
+
     /// <summary>
     /// Checks to see if the local container runtime is available. This is used to give nice errors to the user.
     /// </summary>
     public Task<bool> IsAvailable();
+}
+
+public static class KnownDaemonTypes {
+    public const string Docker = nameof(Docker);
+    public static readonly string[] SupportedLocalDaemonTypes = new [] { Docker };
 }

--- a/Microsoft.NET.Build.Containers/LocalDaemons/ILocalDaemon.cs
+++ b/Microsoft.NET.Build.Containers/LocalDaemons/ILocalDaemon.cs
@@ -3,7 +3,19 @@
 
 namespace Microsoft.NET.Build.Containers;
 
+/// <summary>
+/// Abstracts over the concept of a local container runtime of some kind. Currently this is only modeled by Docker, 
+/// but users have expressed desires for Podman, nerdctl, etc as well so this kind of abstraction makes sense to have.
+/// </summary>
 public interface ILocalDaemon {
+
+    /// <summary>
+    /// Loads an image (presumably from a tarball) into the local container runtime.
+    /// </summary>
     public Task Load(Image image, ImageReference sourceReference, ImageReference destinationReference);
+    
+    /// <summary>
+    /// Checks to see if the local container runtime is available. This is used to give nice errors to the user.
+    /// </summary>
     public Task<bool> IsAvailable();
 }

--- a/Microsoft.NET.Build.Containers/LocalDaemons/LocalDocker.cs
+++ b/Microsoft.NET.Build.Containers/LocalDaemons/LocalDocker.cs
@@ -10,6 +10,12 @@ namespace Microsoft.NET.Build.Containers;
 
 public class LocalDocker: ILocalDaemon
 {
+    private readonly Action<string> logger;
+
+    public LocalDocker(Action<string> logger) {
+        this.logger = logger;
+    }
+
     public async Task Load(Image image, ImageReference sourceReference, ImageReference destinationReference)
     {
         // call `docker load` and get it ready to receive input
@@ -42,6 +48,7 @@ public class LocalDocker: ILocalDaemon
     public async Task<bool> IsAvailable()
     {
         var config = await GetConfig();
+        logger(config is null ? "config is null" : $"config is {config.RootElement.ToString()}");
         if (config is null) return false;
         if (config.RootElement.TryGetProperty("ServerErrors", out var errorProperty)
             && errorProperty.ValueKind == JsonValueKind.Array 

--- a/Microsoft.NET.Build.Containers/LocalDaemons/LocalDocker.cs
+++ b/Microsoft.NET.Build.Containers/LocalDaemons/LocalDocker.cs
@@ -61,7 +61,7 @@ public class LocalDocker: ILocalDaemon
     }
 
     private async Task<JsonDocument> GetConfig() {
-        var psi = new ProcessStartInfo("docker", "info --format='{{json .}}'") {
+        var psi = new ProcessStartInfo("docker", "info --format=\"{{json .}}\"") {
             RedirectStandardOutput = true,
             RedirectStandardError = true
         };

--- a/Microsoft.NET.Build.Containers/LocalDaemons/LocalDocker.cs
+++ b/Microsoft.NET.Build.Containers/LocalDaemons/LocalDocker.cs
@@ -62,12 +62,13 @@ public class LocalDocker: ILocalDaemon
 
     private async Task<JsonDocument> GetConfig() {
         var psi = new ProcessStartInfo("docker", "info --format='{{json .}}'") {
-            RedirectStandardOutput = true
+            RedirectStandardOutput = true,
+            RedirectStandardError = true
         };
         var proc = Process.Start(psi);
         if (proc is null) throw new Exception("Failed to start docker client process");
         await proc.WaitForExitAsync();
-        if (proc.ExitCode != 0) throw new Exception($"Failed to get docker info - {await proc.StandardOutput.ReadToEndAsync()}");
+        if (proc.ExitCode != 0) throw new Exception($"Failed to get docker info({proc.ExitCode})\n{await proc.StandardOutput.ReadToEndAsync()}\n{await proc.StandardError.ReadToEndAsync()}");
         return await JsonDocument.ParseAsync(proc.StandardOutput.BaseStream);
     }
 

--- a/Microsoft.NET.Build.Containers/Microsoft.NET.Build.Containers.csproj
+++ b/Microsoft.NET.Build.Containers/Microsoft.NET.Build.Containers.csproj
@@ -28,7 +28,7 @@
 
   <!-- net472 builds manually import files to compile -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
-    <Compile Remove="*.*" />
+    <Compile Remove="**/*.*" />
     <Compile Include="ReferenceParser.cs" />
     <Compile Include="KnownStrings.cs" />
     <Compile Include="ParseContainerProperties.cs" />

--- a/Microsoft.NET.Build.Containers/Registry.cs
+++ b/Microsoft.NET.Build.Containers/Registry.cs
@@ -28,8 +28,8 @@ public record struct Registry
     private const string DockerManifestListV2 = "application/vnd.docker.distribution.manifest.list.v2+json";
     private const string DockerContainerV1 = "application/vnd.docker.container.image.v1+json";
 
-    private readonly Uri BaseUri;
-    private readonly string RegistryName => BaseUri.Host;
+    public readonly Uri BaseUri;
+    private readonly string RegistryName => BaseUri.GetComponents(UriComponents.HostAndPort, UriFormat.Unescaped);
 
     public Registry(Uri baseUri)
     {
@@ -95,7 +95,7 @@ public record struct Registry
     {
         var client = GetClient();
         var initialManifestResponse = await GetManifest(repositoryName, reference).ConfigureAwait(false);
-        
+
         return initialManifestResponse.Content.Headers.ContentType?.MediaType switch {
             DockerManifestV2 => await TryReadSingleImage(repositoryName, await initialManifestResponse.Content.ReadFromJsonAsync<ManifestV2>().ConfigureAwait(false)).ConfigureAwait(false),
             DockerManifestListV2 => await TryPickBestImageFromManifestList(repositoryName, reference, await initialManifestResponse.Content.ReadFromJsonAsync<ManifestListV2>().ConfigureAwait(false), runtimeIdentifier, runtimeIdentifierGraphPath).ConfigureAwait(false),
@@ -106,13 +106,13 @@ public record struct Registry
     private async Task<Image?> TryReadSingleImage(string repositoryName, ManifestV2 manifest) {
         var config = manifest.config;
         string configSha = config.digest;
-        
+
         var blobResponse = await GetBlob(repositoryName, configSha).ConfigureAwait(false);
 
         JsonNode? configDoc = JsonNode.Parse(await blobResponse.Content.ReadAsStringAsync().ConfigureAwait(false));
         Debug.Assert(configDoc is not null);
 
-        return new Image(manifest, configDoc, repositoryName, this);
+        return new Image(manifest, configDoc);
     }
 
     async Task<Image?> TryPickBestImageFromManifestList(string repositoryName, string reference, ManifestListV2 manifestList, string runtimeIdentifier, string runtimeIdentifierGraphPath) {
@@ -157,13 +157,13 @@ public record struct Registry
                 }
             }
         }
-        
+
         var graph = new RuntimeGraph(runtimeDescriptionSet);
         return (ridDict, graph);
     }
 
     private static string? CreateRidForPlatform(PlatformInformation platform)
-    {   
+    {
         // we only support linux and windows containers explicitly, so anything else we should skip past.
         // there are theoretically other platforms/architectures that Docker supports (s390x?), but we are
         // deliberately ignoring them without clear user signal.
@@ -188,7 +188,7 @@ public record struct Registry
             "arm64" => "arm64",
             _ => null
         };
-        
+
         if (osPart is null || platformPart is null) return null;
         return $"{osPart}{versionPart ?? ""}-{platformPart}";
     }
@@ -203,12 +203,12 @@ public record struct Registry
     }
 
     /// <summary>
-    /// Ensure a blob associated with <paramref name="name"/> from the registry is available locally.
+    /// Ensure a blob associated with <paramref name="repository"/> from the registry is available locally.
     /// </summary>
-    /// <param name="name">Name of the associated image.</param>
+    /// <param name="repository">Name of the associated image repository.</param>
     /// <param name="descriptor"><see cref="Descriptor"/> that describes the blob.</param>
     /// <returns>Local path to the (decompressed) blob content.</returns>
-    public async Task<string> DownloadBlob(string name, Descriptor descriptor)
+    public async Task<string> DownloadBlob(string repository, Descriptor descriptor)
     {
         string localPath = ContentStore.PathForDescriptor(descriptor);
 
@@ -222,7 +222,7 @@ public record struct Registry
 
         HttpClient client = GetClient();
 
-        var response = await client.GetAsync(new Uri(BaseUri, $"/v2/{name}/blobs/{descriptor.Digest}"), HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
+        var response = await client.GetAsync(new Uri(BaseUri, $"/v2/{repository}/blobs/{descriptor.Digest}"), HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
 
         response.EnsureSuccessStatusCode();
 
@@ -239,17 +239,17 @@ public record struct Registry
         return localPath;
     }
 
-    public async Task Push(Layer layer, string name, Action<string> logProgressMessage)
+    public async Task Push(Layer layer, string repository, Action<string> logProgressMessage)
     {
         string digest = layer.Descriptor.Digest;
 
         using (FileStream contents = File.OpenRead(layer.BackingFile))
         {
-            await UploadBlob(name, digest, contents).ConfigureAwait(false);
+            await UploadBlob(repository, digest, contents).ConfigureAwait(false);
         }
     }
 
-    private readonly async Task<UriBuilder> UploadBlobChunked(string name, string digest, Stream contents, HttpClient client, UriBuilder uploadUri) {
+    private readonly async Task<UriBuilder> UploadBlobChunked(string repository, string digest, Stream contents, HttpClient client, UriBuilder uploadUri) {
         Uri patchUri = uploadUri.Uri;
         var localUploadUri = new UriBuilder(uploadUri.Uri);
         localUploadUri.Query += $"&digest={Uri.EscapeDataString(digest)}";
@@ -306,7 +306,7 @@ public record struct Registry
         }
     }
 
-    private readonly async Task<UriBuilder> UploadBlobWhole(string name, string digest, Stream contents, HttpClient client, UriBuilder uploadUri) {
+    private readonly async Task<UriBuilder> UploadBlobWhole(string repository, string digest, Stream contents, HttpClient client, UriBuilder uploadUri) {
         StreamContent content = new StreamContent(contents);
         content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
         content.Headers.ContentLength = contents.Length;
@@ -319,9 +319,9 @@ public record struct Registry
         return GetNextLocation(patchResponse);
     }
 
-    private readonly async Task<UriBuilder> StartUploadSession(string name, string digest, HttpClient client) {
-        Uri startUploadUri = new Uri(BaseUri, $"/v2/{name}/blobs/uploads/");
-        
+    private readonly async Task<UriBuilder> StartUploadSession(string repository, string digest, HttpClient client) {
+        Uri startUploadUri = new Uri(BaseUri, $"/v2/{repository}/blobs/uploads/");
+
         HttpResponseMessage pushResponse = await client.PostAsync(startUploadUri, content: null).ConfigureAwait(false);
 
         if (pushResponse.StatusCode != HttpStatusCode.Accepted)
@@ -333,9 +333,9 @@ public record struct Registry
         return GetNextLocation(pushResponse);
     }
 
-    private readonly async Task<UriBuilder> UploadBlobContents(string name, string digest, Stream contents, HttpClient client, UriBuilder uploadUri) {
-        if (SupportsChunkedUpload) return await UploadBlobChunked(name, digest, contents, client, uploadUri).ConfigureAwait(false);
-        else return await UploadBlobWhole(name, digest, contents, client, uploadUri).ConfigureAwait(false);
+    private readonly async Task<UriBuilder> UploadBlobContents(string repository, string digest, Stream contents, HttpClient client, UriBuilder uploadUri) {
+        if (SupportsChunkedUpload) return await UploadBlobChunked(repository, digest, contents, client, uploadUri).ConfigureAwait(false);
+        else return await UploadBlobWhole(repository, digest, contents, client, uploadUri).ConfigureAwait(false);
     }
 
     private static async Task FinishUploadSession(string digest, HttpClient client, UriBuilder uploadUri) {
@@ -353,11 +353,11 @@ public record struct Registry
         }
     }
 
-    private readonly async Task UploadBlob(string name, string digest, Stream contents)
+    private readonly async Task UploadBlob(string repository, string digest, Stream contents)
     {
         HttpClient client = GetClient();
 
-        if (await BlobAlreadyUploaded(name, digest, client).ConfigureAwait(false))
+        if (await BlobAlreadyUploaded(repository, digest, client).ConfigureAwait(false))
         {
             // Already there!
             return;
@@ -365,17 +365,17 @@ public record struct Registry
 
         // Three steps to this process:
         // * start an upload session
-        var uploadUri = await StartUploadSession(name, digest, client).ConfigureAwait(false);
+        var uploadUri = await StartUploadSession(repository, digest, client).ConfigureAwait(false);
         // * upload the blob
-        var finalChunkUri = await UploadBlobContents(name, digest, contents, client, uploadUri).ConfigureAwait(false);
+        var finalChunkUri = await UploadBlobContents(repository, digest, contents, client, uploadUri).ConfigureAwait(false);
         // * finish the upload session
         await FinishUploadSession(digest, client, finalChunkUri).ConfigureAwait(false);
-        
+
     }
 
-    private readonly async Task<bool> BlobAlreadyUploaded(string name, string digest, HttpClient client)
+    private readonly async Task<bool> BlobAlreadyUploaded(string repository, string digest, HttpClient client)
     {
-        HttpResponseMessage response = await client.SendAsync(new HttpRequestMessage(HttpMethod.Head, new Uri(BaseUri, $"/v2/{name}/blobs/{digest}"))).ConfigureAwait(false);
+        HttpResponseMessage response = await client.SendAsync(new HttpRequestMessage(HttpMethod.Head, new Uri(BaseUri, $"/v2/{repository}/blobs/{digest}"))).ConfigureAwait(false);
 
         if (response.StatusCode == HttpStatusCode.OK)
         {
@@ -414,37 +414,37 @@ public record struct Registry
         return client;
     }
 
-    public async Task Push(Image x, string name, string? tag, string baseName, Action<string> logProgressMessage)
+    public async Task Push(Image x, ImageReference source, ImageReference destination, Action<string> logProgressMessage)
     {
-        tag ??= "latest";
 
         HttpClient client = GetClient();
-        var reg = this;
+        Registry destinationRegistry = (destination.Registry!).Value;
 
         Func<Descriptor, Task> uploadLayerFunc = async (descriptor) =>
         {
             string digest = descriptor.Digest;
-            logProgressMessage($"Uploading layer {digest} to {reg.RegistryName}");
-            if (await reg.BlobAlreadyUploaded(name, digest, client).ConfigureAwait(false))
+
+            logProgressMessage($"Uploading layer {digest} to {destinationRegistry.RegistryName}");
+            if (await destinationRegistry.BlobAlreadyUploaded(destination.Repository, digest, client).ConfigureAwait(false))
             {
                 logProgressMessage($"Layer {digest} already existed");
                 return;
             }
 
             // Blob wasn't there; can we tell the server to get it from the base image?
-            HttpResponseMessage pushResponse = await client.PostAsync(new Uri(reg.BaseUri, $"/v2/{name}/blobs/uploads/?mount={digest}&from={baseName}"), content: null).ConfigureAwait(false);
+            HttpResponseMessage pushResponse = await client.PostAsync(new Uri(destinationRegistry.BaseUri, $"/v2/{destination.Repository}/blobs/uploads/?mount={digest}&from={source.Repository}"), content: null).ConfigureAwait(false);
 
             if (pushResponse.StatusCode != HttpStatusCode.Created)
             {
                 // The blob wasn't already available in another namespace, so fall back to explicitly uploading it
 
-                if (x.originatingRegistry is { } registry)
+                if (source.Registry is { } sourceRegistry)
                 {
                     // Ensure the blob is available locally
-                    await registry.DownloadBlob(x.OriginatingName, descriptor).ConfigureAwait(false);
+                    await sourceRegistry.DownloadBlob(source.Repository, descriptor).ConfigureAwait(false);
                     // Then push it to the destination registry
-                    await reg.Push(Layer.FromDescriptor(descriptor), name, logProgressMessage).ConfigureAwait(false);
-                    logProgressMessage($"Finished uploading layer {digest} to {reg.RegistryName}");
+                    await destinationRegistry.Push(Layer.FromDescriptor(descriptor), destination.Repository, logProgressMessage).ConfigureAwait(false);
+                    logProgressMessage($"Finished uploading layer {digest} to {destinationRegistry.RegistryName}");
                 }
                 else {
                     throw new NotImplementedException("Need a good error for 'couldn't download a thing because no link to registry'");
@@ -468,7 +468,7 @@ public record struct Registry
         {
             var configDigest = Image.GetDigest(x.config);
             logProgressMessage($"Uploading config to registry at blob {configDigest}");
-            await UploadBlob(name, configDigest, stringStream).ConfigureAwait(false);
+            await UploadBlob(destination.Repository, configDigest, stringStream).ConfigureAwait(false);
             logProgressMessage($"Uploaded config to registry");
         }
 
@@ -477,7 +477,7 @@ public record struct Registry
         string jsonString = JsonSerializer.SerializeToNode(x.manifest)?.ToJsonString() ?? "";
         HttpContent manifestUploadContent = new StringContent(jsonString);
         manifestUploadContent.Headers.ContentType = new MediaTypeHeaderValue(DockerManifestV2);
-        var putResponse = await client.PutAsync(new Uri(BaseUri, $"/v2/{name}/manifests/{manifestDigest}"), manifestUploadContent).ConfigureAwait(false);
+        var putResponse = await client.PutAsync(new Uri(BaseUri, $"/v2/{destination.Repository}/manifests/{manifestDigest}"), manifestUploadContent).ConfigureAwait(false);
 
         if (!putResponse.IsSuccessStatusCode)
         {
@@ -485,14 +485,14 @@ public record struct Registry
         }
         logProgressMessage($"Uploaded manifest to {RegistryName}");
 
-        logProgressMessage($"Uploading tag {tag} to {RegistryName}");
-        var putResponse2 = await client.PutAsync(new Uri(BaseUri, $"/v2/{name}/manifests/{tag}"), manifestUploadContent).ConfigureAwait(false);
+        logProgressMessage($"Uploading tag {destination.Tag} to {RegistryName}");
+        var putResponse2 = await client.PutAsync(new Uri(BaseUri, $"/v2/{destination.Repository}/manifests/{destination.Tag}"), manifestUploadContent).ConfigureAwait(false);
 
         if (!putResponse2.IsSuccessStatusCode)
         {
             throw new ContainerHttpException("Registry push failed.", putResponse2.RequestMessage?.RequestUri?.ToString(), jsonString);
         }
 
-        logProgressMessage($"Uploaded tag {tag} to {RegistryName}");
+        logProgressMessage($"Uploaded tag {destination.Tag} to {RegistryName}");
     }
 }

--- a/Microsoft.NET.Build.Containers/Registry.cs
+++ b/Microsoft.NET.Build.Containers/Registry.cs
@@ -97,8 +97,8 @@ public record struct Registry
         var initialManifestResponse = await GetManifest(repositoryName, reference).ConfigureAwait(false);
 
         return initialManifestResponse.Content.Headers.ContentType?.MediaType switch {
-            DockerManifestV2 => await ReadSingleImage(repositoryName, await initialManifestResponse.Content.ReadFromJsonAsync<ManifestV2>()).ConfigureAwait(false),
-            DockerManifestListV2 => await PickBestImageFromManifestList(repositoryName, reference, await initialManifestResponse.Content.ReadFromJsonAsync<ManifestListV2>(), runtimeIdentifier, runtimeIdentifierGraphPath).ConfigureAwait(false),
+            DockerManifestV2 => await ReadSingleImage(repositoryName, await initialManifestResponse.Content.ReadFromJsonAsync<ManifestV2>().ConfigureAwait(false)).ConfigureAwait(false),
+            DockerManifestListV2 => await PickBestImageFromManifestList(repositoryName, reference, await initialManifestResponse.Content.ReadFromJsonAsync<ManifestListV2>().ConfigureAwait(false), runtimeIdentifier, runtimeIdentifierGraphPath).ConfigureAwait(false),
             var unknownMediaType => throw new NotImplementedException($"The manifest for {repositoryName}:{reference} from registry {BaseUri} was an unknown type: {unknownMediaType}. Please raise an issue at https://github.com/dotnet/sdk-container-builds/issues with this message.")
         };
     }
@@ -124,7 +124,7 @@ public record struct Registry
         }
         var matchingManifest = ridDict[bestManifestRid];
         var manifestResponse = await GetManifest(repositoryName, matchingManifest.digest).ConfigureAwait(false);
-        return await ReadSingleImage(repositoryName, await manifestResponse.Content.ReadFromJsonAsync<ManifestV2>()).ConfigureAwait(false);
+        return await ReadSingleImage(repositoryName, await manifestResponse.Content.ReadFromJsonAsync<ManifestV2>().ConfigureAwait(false)).ConfigureAwait(false);
     }
 
     private async Task<HttpResponseMessage> GetManifest(string repositoryName, string reference)

--- a/Test.Microsoft.NET.Build.Containers.Filesystem/CreateNewImageTests.cs
+++ b/Test.Microsoft.NET.Build.Containers.Filesystem/CreateNewImageTests.cs
@@ -105,7 +105,7 @@ public class CreateNewImageTests
         pcp.FullyQualifiedBaseImageName = "mcr.microsoft.com/dotnet/runtime:7.0";
         pcp.ContainerRegistry = "localhost:5010";
         pcp.ContainerImageName = "dotnet/testimage";
-        pcp.ContainerImageTags = new [] { "5.0", "latest"};
+        pcp.ContainerImageTags = new[] { "5.0", "latest" };
 
         Assert.IsTrue(pcp.Execute());
         Assert.AreEqual("mcr.microsoft.com", pcp.ParsedContainerRegistry);
@@ -113,7 +113,7 @@ public class CreateNewImageTests
         Assert.AreEqual("7.0", pcp.ParsedContainerTag);
 
         Assert.AreEqual("dotnet/testimage", pcp.NewContainerImageName);
-        CollectionAssert.AreEquivalent(new []{ "5.0", "latest"}, pcp.NewContainerTags);
+        CollectionAssert.AreEquivalent(new[] { "5.0", "latest" }, pcp.NewContainerTags);
 
         CreateNewImage cni = new CreateNewImage();
         cni.BaseRegistry = pcp.ParsedContainerRegistry;

--- a/Test.Microsoft.NET.Build.Containers.Filesystem/CreateNewImageTests.cs
+++ b/Test.Microsoft.NET.Build.Containers.Filesystem/CreateNewImageTests.cs
@@ -193,6 +193,7 @@ public class CreateNewImageTests
         cni.ContainerEnvironmentVariables = pcp.NewContainerEnvironmentVariables;
         cni.ContainerRuntimeIdentifier = "linux-x64";
         cni.RuntimeIdentifierGraphPath = RuntimeGraphFilePath();
+        cni.LocalContainerDaemon = global::Microsoft.NET.Build.Containers.KnownDaemonTypes.Docker;
 
         Assert.IsTrue(cni.Execute());
 

--- a/Test.Microsoft.NET.Build.Containers.Filesystem/CreateNewImageTests.cs
+++ b/Test.Microsoft.NET.Build.Containers.Filesystem/CreateNewImageTests.cs
@@ -161,7 +161,7 @@ public class CreateNewImageTests
 
         ParseContainerProperties pcp = new ParseContainerProperties();
         pcp.FullyQualifiedBaseImageName = "mcr.microsoft.com/dotnet/runtime:6.0";
-        pcp.ContainerRegistry = "localhost:5010";
+        pcp.ContainerRegistry = "";
         pcp.ContainerImageName = "dotnet/envvarvalidation";
         pcp.ContainerImageTag = "latest";
 

--- a/Test.Microsoft.NET.Build.Containers.Filesystem/CreateNewImageTests.cs
+++ b/Test.Microsoft.NET.Build.Containers.Filesystem/CreateNewImageTests.cs
@@ -29,7 +29,7 @@ public class CreateNewImageTests
         }
     }
 
-    public static string RuntimeGraphFilePath() 
+    public static string RuntimeGraphFilePath()
     {
         string dotnetRoot = ToolsetUtils.GetDotNetPath();
         DirectoryInfo sdksDir = new(Path.Combine(dotnetRoot, "sdk"));
@@ -161,7 +161,7 @@ public class CreateNewImageTests
 
         ParseContainerProperties pcp = new ParseContainerProperties();
         pcp.FullyQualifiedBaseImageName = "mcr.microsoft.com/dotnet/runtime:6.0";
-        pcp.ContainerRegistry = "";
+        pcp.ContainerRegistry = "localhost:5010";
         pcp.ContainerImageName = "dotnet/envvarvalidation";
         pcp.ContainerImageTag = "latest";
 

--- a/Test.Microsoft.NET.Build.Containers.Filesystem/EndToEnd.cs
+++ b/Test.Microsoft.NET.Build.Containers.Filesystem/EndToEnd.cs
@@ -115,7 +115,7 @@ public class EndToEnd
         var sourceReference = new ImageReference(registry, DockerRegistryManager.BaseImage, DockerRegistryManager.Net6ImageTag);
         var destinationReference = new ImageReference(registry, NewImageName(), "latest");
 
-        await LocalDocker.Load(x, sourceReference, destinationReference).ConfigureAwait(false);
+        await new LocalDocker().Load(x, sourceReference, destinationReference).ConfigureAwait(false);
 
         // Run the image
         new BasicCommand(TestContext, "docker", "run", "--rm", "--tty", $"{NewImageName()}:latest")
@@ -322,7 +322,7 @@ public class EndToEnd
         // Load the image into the local Docker daemon
         var sourceReference = new ImageReference(registry, DockerRegistryManager.BaseImage, DockerRegistryManager.Net7ImageTag);
         var destinationReference = new ImageReference(registry, NewImageName(), rid);
-        await LocalDocker.Load(x, sourceReference, destinationReference).ConfigureAwait(false); ;
+        await new LocalDocker().Load(x, sourceReference, destinationReference).ConfigureAwait(false);
 
         // Run the image
         new BasicCommand(

--- a/Test.Microsoft.NET.Build.Containers.Filesystem/EndToEnd.cs
+++ b/Test.Microsoft.NET.Build.Containers.Filesystem/EndToEnd.cs
@@ -115,7 +115,7 @@ public class EndToEnd
         var sourceReference = new ImageReference(registry, DockerRegistryManager.BaseImage, DockerRegistryManager.Net6ImageTag);
         var destinationReference = new ImageReference(registry, NewImageName(), "latest");
 
-        await new LocalDocker().Load(x, sourceReference, destinationReference).ConfigureAwait(false);
+        await new LocalDocker(Console.WriteLine).Load(x, sourceReference, destinationReference).ConfigureAwait(false);
 
         // Run the image
         new BasicCommand(TestContext, "docker", "run", "--rm", "--tty", $"{NewImageName()}:latest")
@@ -322,7 +322,7 @@ public class EndToEnd
         // Load the image into the local Docker daemon
         var sourceReference = new ImageReference(registry, DockerRegistryManager.BaseImage, DockerRegistryManager.Net7ImageTag);
         var destinationReference = new ImageReference(registry, NewImageName(), rid);
-        await new LocalDocker().Load(x, sourceReference, destinationReference).ConfigureAwait(false);
+        await new LocalDocker(Console.WriteLine).Load(x, sourceReference, destinationReference).ConfigureAwait(false);
 
         // Run the image
         new BasicCommand(

--- a/Test.Microsoft.NET.Build.Containers/DockerDaemonTests.cs
+++ b/Test.Microsoft.NET.Build.Containers/DockerDaemonTests.cs
@@ -21,6 +21,6 @@ public class DockerDaemonTests {
     [TestMethod]
     public async Task Can_detect_when_daemon_is_running() {
         var available = await new LocalDocker(Console.WriteLine).IsAvailable();
-        Assert.IsFalse(available, "No daemon should be listening at that port");
+        Assert.IsTrue(available, "Should have found a working daemon");
     }
 }

--- a/Test.Microsoft.NET.Build.Containers/DockerDaemonTests.cs
+++ b/Test.Microsoft.NET.Build.Containers/DockerDaemonTests.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using global::Microsoft.NET.Build.Containers;
 
 namespace Test.Microsoft.NET.Build.Containers;
@@ -11,7 +14,7 @@ public class DockerDaemonTests {
         // mimic no daemon running by setting the DOCKER_HOST to a nonexistent socket
         try {
             System.Environment.SetEnvironmentVariable("DOCKER_HOST", "tcp://123.123.123.123:12345");
-            var available = await new LocalDocker(Console.WriteLine).IsAvailable();
+            var available = await new LocalDocker(Console.WriteLine).IsAvailable().ConfigureAwait(false);
             Assert.IsFalse(available, "No daemon should be listening at that port");
         } finally {
             System.Environment.SetEnvironmentVariable("DOCKER_HOST", null);
@@ -20,7 +23,7 @@ public class DockerDaemonTests {
 
     [TestMethod]
     public async Task Can_detect_when_daemon_is_running() {
-        var available = await new LocalDocker(Console.WriteLine).IsAvailable();
+        var available = await new LocalDocker(Console.WriteLine).IsAvailable().ConfigureAwait(false);
         Assert.IsTrue(available, "Should have found a working daemon");
     }
 }

--- a/Test.Microsoft.NET.Build.Containers/DockerDaemonTests.cs
+++ b/Test.Microsoft.NET.Build.Containers/DockerDaemonTests.cs
@@ -1,0 +1,26 @@
+using global::Microsoft.NET.Build.Containers;
+
+namespace Test.Microsoft.NET.Build.Containers;
+
+[TestClass]
+public class DockerDaemonTests {
+
+
+    [TestMethod]
+    public async Task Can_detect_when_no_daemon_is_running() {
+        // mimic no daemon running by setting the DOCKER_HOST to a nonexistent socket
+        try {
+            System.Environment.SetEnvironmentVariable("DOCKER_HOST", "tcp://123.123.123.123:12345");
+            var available = await new LocalDocker().IsAvailable();
+            Assert.IsFalse(available, "No daemon should be listening at that port");
+        } finally {
+            System.Environment.SetEnvironmentVariable("DOCKER_HOST", null);
+        }
+    }
+
+    [TestMethod]
+    public async Task Can_detect_when_daemon_is_running() {
+        var available = await new LocalDocker().IsAvailable();
+        Assert.IsFalse(available, "No daemon should be listening at that port");
+    }
+}

--- a/Test.Microsoft.NET.Build.Containers/DockerDaemonTests.cs
+++ b/Test.Microsoft.NET.Build.Containers/DockerDaemonTests.cs
@@ -11,7 +11,7 @@ public class DockerDaemonTests {
         // mimic no daemon running by setting the DOCKER_HOST to a nonexistent socket
         try {
             System.Environment.SetEnvironmentVariable("DOCKER_HOST", "tcp://123.123.123.123:12345");
-            var available = await new LocalDocker().IsAvailable();
+            var available = await new LocalDocker(Console.WriteLine).IsAvailable();
             Assert.IsFalse(available, "No daemon should be listening at that port");
         } finally {
             System.Environment.SetEnvironmentVariable("DOCKER_HOST", null);
@@ -20,7 +20,7 @@ public class DockerDaemonTests {
 
     [TestMethod]
     public async Task Can_detect_when_daemon_is_running() {
-        var available = await new LocalDocker().IsAvailable();
+        var available = await new LocalDocker(Console.WriteLine).IsAvailable();
         Assert.IsFalse(available, "No daemon should be listening at that port");
     }
 }

--- a/containerize/Program.cs
+++ b/containerize/Program.cs
@@ -73,6 +73,11 @@ var entrypointArgsOpt = new Option<string[]>(
     AllowMultipleArgumentsPerToken = true
 };
 
+var localContainerDaemonOpt = new Option<string>(
+    name: "--localcontainerdaemon",
+    description: "The local daemon type to push to"
+).FromAmong(KnownDaemonTypes.SupportedLocalDaemonTypes);
+
 var labelsOpt = new Option<string[]>(
     name: "--labels",
     description: "Labels that the image configuration will include in metadata.",
@@ -101,7 +106,7 @@ var portsOpt = new Option<Port[]>(
         var ports = result.Tokens.Select(x => x.Value).ToArray();
         var goodPorts = new List<Port>();
         var badPorts = new List<(string, ContainerHelpers.ParsePortError)>();
-        
+
         foreach (var port in ports) {
             var split = port.Split('/');
             if (split.Length != 2) {
@@ -173,7 +178,8 @@ RootCommand root = new RootCommand("Containerize an application without Docker."
     portsOpt,
     envVarsOpt,
     ridOpt,
-    ridGraphPathOpt
+    ridGraphPathOpt,
+    localContainerDaemonOpt
 };
 
 root.SetHandler(async (context) =>
@@ -193,7 +199,8 @@ root.SetHandler(async (context) =>
     string[] _envVars = context.ParseResult.GetValueForOption(envVarsOpt) ?? Array.Empty<string>();
     string _rid = context.ParseResult.GetValueForOption(ridOpt) ?? "";
     string _ridGraphPath = context.ParseResult.GetValueForOption(ridGraphPathOpt) ?? "";
-    await ContainerBuilder.Containerize(_publishDir, _workingDir, _baseReg, _baseName, _baseTag, _entrypoint, _entrypointArgs, _name, _tags, _outputReg, _labels, _ports, _envVars, _rid, _ridGraphPath).ConfigureAwait(false);
+    string _localContainerDaemon = context.ParseResult.GetValueForOption(localContainerDaemonOpt) ?? "";
+    await ContainerBuilder.Containerize(_publishDir, _workingDir, _baseReg, _baseName, _baseTag, _entrypoint, _entrypointArgs, _name, _tags, _outputReg, _labels, _ports, _envVars, _rid, _ridGraphPath, _localContainerDaemon).ConfigureAwait(false);
 });
 
 return await root.InvokeAsync(args).ConfigureAwait(false);

--- a/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -54,13 +54,19 @@
 
             <!-- An empty ContainerRegistry implies pushing to the local daemon, putting this here for documentation purposes -->
             <!-- <ContainerRegistry></ContainerRegistry> -->
+            
+            <!-- Set which local container daemon to use. We only explicitly support Docker (or things that mimic Docker APIs and binary names) at the moment. -->
+            <LocalContainerDaemon Condition="'$(LocalContainerDaemon)' == ''">Docker</LocalContainerDaemon>
 
             <!-- Note: spaces will be replaced with '-' in ContainerImageName and ContainerImageTag -->
             <ContainerImageName Condition="'$(ContainerImageName)' == ''">$(AssemblyName)</ContainerImageName>
+            
             <!-- Only default a tag name if no tag names at all are provided -->
             <ContainerImageTag Condition="'$(ContainerImageTag)' == '' and '$(ContainerImageTags)' == ''">$(Version)</ContainerImageTag>
             <ContainerImageTag Condition="'$(AutoGenerateImageTag)' == 'true' and '$(ContainerImageTags)' == ''">$([System.DateTime]::UtcNow.ToString('yyyyMMddhhmmss'))</ContainerImageTag>
+            
             <ContainerWorkingDirectory Condition="'$(ContainerWorkingDirectory)' == ''">/app</ContainerWorkingDirectory>
+            
             <!-- The Container RID should default to the RID used for the entire build (to ensure things run on the platform they are built for), but the user knows best and so should be able to set it explicitly.
                  For builds that have a RID, we default to that RID. Otherwise, we default to the RID of the currently-executing SDK. -->
             <ContainerRuntimeIdentifier Condition="'$(ContainerRuntimeIdentifier)' == '' and '$(IsRidAgnostic)' != 'true'">$(RuntimeIdentifier)</ContainerRuntimeIdentifier>
@@ -162,6 +168,7 @@
                         BaseRegistry="$(ContainerBaseRegistry)"
                         BaseImageName="$(ContainerBaseName)"
                         BaseImageTag="$(ContainerBaseTag)"
+                        LocalContainerDaemon="$(LocalContainerDaemon)"
                         OutputRegistry="$(ContainerRegistry)"
                         ImageName="$(ContainerImageName)"
                         ImageTags="@(ContainerImageTags)"


### PR DESCRIPTION
This PR takes the chance to define an interface for working with a local container daemon of some kind, refactors the existing `LocalDocker` code to use that interface, and adds an explicit check for that local daemon before use.

Closes #278 