### PR TITLE
added command utils, refactored tests

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,20 +1,21 @@
 <Project>
-    <PropertyGroup>
-        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    </PropertyGroup>
-    <ItemGroup>
-        <PackageVersion Include="coverlet.collector" Version="3.1.2" />
-        <PackageVersion Include="GitHubActionsTestLogger" Version="2.0.1" />
-        <PackageVersion Include="Microsoft.Build.Locator" Version="1.5.5" />
-        <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.3.1" />
-        <PackageVersion Include="Microsoft.Build" Version="17.3.1" />
-        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-        <PackageVersion Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0" />
-        <PackageVersion Include="MSTest.TestAdapter" Version="2.3.0-preview-20220810-02" />
-        <PackageVersion Include="MSTest.TestFramework" Version="2.2.10" />
-        <PackageVersion Include="Nerdbank.GitVersioning" Version="3.5.109" />
-        <PackageVersion Include="NuGet.Packaging" Version="6.3.1" />
-        <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
-        <PackageVersion Include="Valleysoft.DockerCredsProvider" Version="2.1.0" />
-    </ItemGroup>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="coverlet.collector" Version="3.1.2" />
+    <PackageVersion Include="FluentAssertions" Version="6.9.0" />
+    <PackageVersion Include="GitHubActionsTestLogger" Version="2.0.1" />
+    <PackageVersion Include="Microsoft.Build.Locator" Version="1.5.5" />
+    <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.3.1" />
+    <PackageVersion Include="Microsoft.Build" Version="17.3.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageVersion Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0" />
+    <PackageVersion Include="MSTest.TestAdapter" Version="2.3.0-preview-20220810-02" />
+    <PackageVersion Include="MSTest.TestFramework" Version="2.2.10" />
+    <PackageVersion Include="Nerdbank.GitVersioning" Version="3.5.109" />
+    <PackageVersion Include="NuGet.Packaging" Version="6.3.1" />
+    <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+    <PackageVersion Include="Valleysoft.DockerCredsProvider" Version="2.1.0" />
+  </ItemGroup>
 </Project>

--- a/Test.Microsoft.NET.Build.Containers.Filesystem/CommandUtils/ArgumentEscaper.cs
+++ b/Test.Microsoft.NET.Build.Containers.Filesystem/CommandUtils/ArgumentEscaper.cs
@@ -1,0 +1,199 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text;
+
+namespace Microsoft.DotNet.CommandUtils
+{
+    internal static class ArgumentEscaper
+    {
+        /// <summary>
+        /// Undo the processing which took place to create string[] args in Main,
+        /// so that the next process will receive the same string[] args
+        /// See here for more info:
+        /// http://blogs.msdn.com/b/twistylittlepassagesallalike/archive/2011/04/23/everyone-quotes-arguments-the-wrong-way.aspx .
+        /// </summary>
+        /// <param name="args"></param>
+        /// <returns></returns>
+        internal static string EscapeAndConcatenateArgArrayForProcessStart(IEnumerable<string> args)
+        {
+            IEnumerable<string> escaped = EscapeArgArray(args);
+            return string.Join(" ", escaped);
+        }
+
+        /// <summary>
+        /// Undo the processing which took place to create string[] args in Main,
+        /// so that the next process will receive the same string[] args
+        /// See here for more info:
+        /// http://blogs.msdn.com/b/twistylittlepassagesallalike/archive/2011/04/23/everyone-quotes-arguments-the-wrong-way.aspx .
+        /// </summary>
+        /// <param name="args"></param>
+        /// <returns></returns>
+        internal static string EscapeAndConcatenateArgArrayForCmdProcessStart(IEnumerable<string> args)
+        {
+            IEnumerable<string> escaped = EscapeArgArrayForCmd(args);
+            return string.Join(" ", escaped);
+        }
+
+        internal static string EscapeSingleArg(string arg)
+        {
+            var sb = new StringBuilder();
+
+            var length = arg.Length;
+            var needsQuotes = length == 0 || ShouldSurroundWithQuotes(arg);
+            var isQuoted = needsQuotes || IsSurroundedWithQuotes(arg);
+
+            if (needsQuotes)
+            {
+                sb.Append('"');
+            }
+
+            for (int i = 0; i < length; ++i)
+            {
+                var backslashCount = 0;
+
+                // Consume All Backslashes
+                while (i < arg.Length && arg[i] == '\\')
+                {
+                    backslashCount++;
+                    i++;
+                }
+
+                // Escape any backslashes at the end of the arg
+                // when the argument is also quoted.
+                // This ensures the outside quote is interpreted as
+                // an argument delimiter
+                if (i == arg.Length && isQuoted)
+                {
+                    sb.Append('\\', 2 * backslashCount);
+                }
+
+                // At then end of the arg, which isn't quoted,
+                // just add the backslashes, no need to escape
+                else if (i == arg.Length)
+                {
+                    sb.Append('\\', backslashCount);
+                }
+
+                // Escape any preceding backslashes and the quote
+                else if (arg[i] == '"')
+                {
+                    sb.Append('\\', (2 * backslashCount) + 1);
+                    sb.Append('"');
+                }
+
+                // Output any consumed backslashes and the character
+                else
+                {
+                    sb.Append('\\', backslashCount);
+                    sb.Append(arg[i]);
+                }
+            }
+
+            if (needsQuotes)
+            {
+                sb.Append('"');
+            }
+
+            return sb.ToString();
+        }
+
+        internal static bool ShouldSurroundWithQuotes(string argument)
+        {
+            // Only quote if whitespace exists in the string
+            return ArgumentContainsWhitespace(argument);
+        }
+
+        internal static bool IsSurroundedWithQuotes(string argument)
+        {
+            return argument.StartsWith("\"", StringComparison.Ordinal) &&
+                   argument.EndsWith("\"", StringComparison.Ordinal);
+        }
+
+        internal static bool ArgumentContainsWhitespace(string argument)
+        {
+            return argument.Contains(" ") || argument.Contains("\t") || argument.Contains("\n");
+        }
+
+        /// <summary>
+        /// Prepare as single argument to
+        /// roundtrip properly through cmd.
+        /// This prefixes every character with the '^' character to force cmd to
+        /// interpret the argument string literally. An alternative option would
+        /// be to do this only for cmd metacharacters.
+        /// See here for more info:
+        /// http://blogs.msdn.com/b/twistylittlepassagesallalike/archive/2011/04/23/everyone-quotes-arguments-the-wrong-way.aspx .
+        /// </summary>
+        /// <param name="argument"></param>
+        /// <returns></returns>
+        private static string EscapeArgForCmd(string argument)
+        {
+            var sb = new StringBuilder();
+
+            var quoted = ShouldSurroundWithQuotes(argument);
+
+            if (quoted)
+            {
+                sb.Append("^\"");
+            }
+
+            // Prepend every character with ^
+            // This is harmless when passing through cmd
+            // and ensures cmd metacharacters are not interpreted
+            // as such
+            foreach (var character in argument)
+            {
+                sb.Append('^');
+                sb.Append(character);
+            }
+
+            if (quoted)
+            {
+                sb.Append("^\"");
+            }
+
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Undo the processing which took place to create string[] args in Main,
+        /// so that the next process will receive the same string[] args
+        /// See here for more info:
+        /// http://blogs.msdn.com/b/twistylittlepassagesallalike/archive/2011/04/23/everyone-quotes-arguments-the-wrong-way.aspx .
+        /// </summary>
+        /// <param name="args"></param>
+        /// <returns></returns>
+        private static IEnumerable<string> EscapeArgArray(IEnumerable<string> args)
+        {
+            var escapedArgs = new List<string>();
+
+            foreach (var arg in args)
+            {
+                escapedArgs.Add(EscapeSingleArg(arg));
+            }
+
+            return escapedArgs;
+        }
+
+        /// <summary>
+        /// This prefixes every character with the '^' character to force cmd to
+        /// interpret the argument string literally. An alternative option would
+        /// be to do this only for cmd metacharacters.
+        /// See here for more info:
+        /// http://blogs.msdn.com/b/twistylittlepassagesallalike/archive/2011/04/23/everyone-quotes-arguments-the-wrong-way.aspx.
+        /// </summary>
+        /// <param name="arguments"></param>
+        /// <returns></returns>
+        private static IEnumerable<string> EscapeArgArrayForCmd(IEnumerable<string> arguments)
+        {
+            var escapedArgs = new List<string>();
+
+            foreach (var arg in arguments)
+            {
+                escapedArgs.Add(EscapeArgForCmd(arg));
+            }
+
+            return escapedArgs;
+        }
+    }
+}

--- a/Test.Microsoft.NET.Build.Containers.Filesystem/CommandUtils/BasicCommand.cs
+++ b/Test.Microsoft.NET.Build.Containers.Filesystem/CommandUtils/BasicCommand.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.CommandUtils
+{
+    internal class BasicCommand : TestCommand
+    {
+        private readonly string _processName;
+
+        internal BasicCommand(TestContext? log, string processName, params string[] args) : base(log)
+        {
+            _processName = processName;
+            Arguments.AddRange(args.Where(a => !string.IsNullOrWhiteSpace(a)));
+        }
+
+        private protected override SdkCommandSpec CreateCommand(IEnumerable<string> args)
+        {
+            var sdkCommandSpec = new SdkCommandSpec()
+            {
+                FileName = _processName,
+                Arguments = args.ToList(),
+                WorkingDirectory = WorkingDirectory
+            };
+            return sdkCommandSpec;
+        }
+    }
+}

--- a/Test.Microsoft.NET.Build.Containers.Filesystem/CommandUtils/Command.cs
+++ b/Test.Microsoft.NET.Build.Containers.Filesystem/CommandUtils/Command.cs
@@ -1,0 +1,202 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.DotNet.CommandUtils
+{
+    internal class Command
+    {
+        private readonly Process _process;
+
+        private readonly bool _trimTrailingNewlines;
+
+        private StreamForwarder? _stdOut;
+        private StreamForwarder? _stdErr;
+        private bool _running;
+
+        public Command(Process process, bool trimtrailingNewlines = false)
+        {
+            _trimTrailingNewlines = trimtrailingNewlines;
+            _process = process ?? throw new ArgumentNullException(nameof(process));
+        }
+
+        public string CommandName => _process.StartInfo.FileName;
+
+        public string CommandArgs => _process.StartInfo.Arguments;
+
+        public CommandResult Execute()
+        {
+            return Execute(_ => { });
+        }
+
+        public CommandResult Execute(Action<Process>? processStarted)
+        {
+            Console.WriteLine($"Running {_process.StartInfo.FileName} {_process.StartInfo.Arguments}");
+            ThrowIfRunning();
+
+            _running = true;
+
+            _process.EnableRaisingEvents = true;
+
+#if DEBUG
+            var sw = Stopwatch.StartNew();
+
+            Console.WriteLine($"> {FormatProcessInfo(_process.StartInfo)}");
+#endif
+            using (var reaper = new ProcessReaper(_process))
+            {
+                _process.Start();
+                processStarted?.Invoke(_process);
+                reaper.NotifyProcessStarted();
+
+                Console.WriteLine($"Process ID: {_process.Id}");
+
+                var taskOut = _stdOut?.BeginRead(_process.StandardOutput);
+                var taskErr = _stdErr?.BeginRead(_process.StandardError);
+                _process.WaitForExit();
+
+                taskOut?.Wait();
+                taskErr?.Wait();
+            }
+
+            var exitCode = _process.ExitCode;
+
+#if DEBUG
+            var message = string.Format($"&lt; {FormatProcessInfo(_process.StartInfo)} exited with {exitCode} in {sw.ElapsedMilliseconds} ms");
+            if (exitCode == 0)
+            {
+                Console.WriteLine(message);
+            }
+            else
+            {
+                Console.WriteLine(message);
+            }
+#endif
+
+            return new CommandResult(
+                _process.StartInfo,
+                exitCode,
+                _stdOut?.CapturedOutput,
+                _stdErr?.CapturedOutput);
+        }
+
+        public Command WorkingDirectory(string projectDirectory)
+        {
+            _process.StartInfo.WorkingDirectory = projectDirectory;
+            return this;
+        }
+
+        public Command EnvironmentVariable(string name, string value)
+        {
+            _process.StartInfo.Environment[name] = value;
+            return this;
+        }
+
+        public Command CaptureStdOut()
+        {
+            ThrowIfRunning();
+            EnsureStdOut();
+            _stdOut!.Capture(_trimTrailingNewlines);
+            return this;
+        }
+
+        public Command CaptureStdErr()
+        {
+            ThrowIfRunning();
+            EnsureStdErr();
+            _stdErr!.Capture(_trimTrailingNewlines);
+            return this;
+        }
+
+        public Command ForwardStdOut(TextWriter? to = null)
+        {
+            ThrowIfRunning();
+            EnsureStdOut();
+
+            if (to == null)
+            {
+                _stdOut!.ForwardTo(writeLine: Console.Out.WriteLine);
+            }
+            else
+            {
+                _stdOut!.ForwardTo(writeLine: to.WriteLine);
+            }
+
+            return this;
+        }
+
+        public Command ForwardStdErr(TextWriter? to = null)
+        {
+            ThrowIfRunning();
+
+            EnsureStdErr();
+
+            if (to == null)
+            {
+                _stdErr!.ForwardTo(writeLine: Console.Error.WriteLine);
+            }
+            else
+            {
+                _stdErr!.ForwardTo(writeLine: to.WriteLine);
+            }
+
+            return this;
+        }
+
+        public Command OnOutputLine(Action<string> handler)
+        {
+            ThrowIfRunning();
+            EnsureStdOut();
+
+            _stdOut!.ForwardTo(writeLine: handler);
+            return this;
+        }
+
+        public Command OnErrorLine(Action<string> handler)
+        {
+            ThrowIfRunning();
+            EnsureStdErr();
+
+            _stdErr!.ForwardTo(writeLine: handler);
+            return this;
+        }
+
+        public Command SetCommandArgs(string commandArgs)
+        {
+            _process.StartInfo.Arguments = commandArgs;
+            return this;
+        }
+
+        private static string FormatProcessInfo(ProcessStartInfo info)
+        {
+            if (string.IsNullOrWhiteSpace(info.Arguments))
+            {
+                return info.FileName;
+            }
+
+            return info.FileName + " " + info.Arguments;
+        }
+
+        private void EnsureStdOut()
+        {
+            _stdOut ??= new StreamForwarder();
+            _process.StartInfo.RedirectStandardOutput = true;
+        }
+
+        private void EnsureStdErr()
+        {
+            _stdErr ??= new StreamForwarder();
+            _process.StartInfo.RedirectStandardError = true;
+        }
+
+        private void ThrowIfRunning([CallerMemberName] string? memberName = null)
+        {
+            if (_running)
+            {
+                throw new InvalidOperationException($"Unable to invoke {memberName} after the command has been run.");
+            }
+        }
+    }
+}

--- a/Test.Microsoft.NET.Build.Containers.Filesystem/CommandUtils/CommandResult.cs
+++ b/Test.Microsoft.NET.Build.Containers.Filesystem/CommandUtils/CommandResult.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+
+namespace Microsoft.DotNet.CommandUtils
+{
+    internal readonly struct CommandResult
+    {
+        internal CommandResult(ProcessStartInfo startInfo, int exitCode, string? stdOut, string? stdErr)
+        {
+            StartInfo = startInfo;
+            ExitCode = exitCode;
+            StdOut = stdOut;
+            StdErr = stdErr;
+        }
+
+        internal ProcessStartInfo StartInfo { get; }
+
+        internal int ExitCode { get; }
+
+        internal string? StdOut { get; }
+
+        internal string? StdErr { get; }
+    }
+}

--- a/Test.Microsoft.NET.Build.Containers.Filesystem/CommandUtils/CommandResultAssertions.cs
+++ b/Test.Microsoft.NET.Build.Containers.Filesystem/CommandUtils/CommandResultAssertions.cs
@@ -1,0 +1,242 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.RegularExpressions;
+using FluentAssertions;
+using FluentAssertions.Execution;
+
+namespace Microsoft.DotNet.CommandUtils
+{
+    internal class CommandResultAssertions
+    {
+        private readonly CommandResult _commandResult;
+
+        internal CommandResultAssertions(CommandResult commandResult)
+        {
+            _commandResult = commandResult;
+        }
+
+        internal AndConstraint<CommandResultAssertions> ExitWith(int expectedExitCode)
+        {
+            Execute.Assertion.ForCondition(_commandResult.ExitCode == expectedExitCode)
+                .FailWith(AppendDiagnosticsTo($"Expected command to exit with {expectedExitCode} but it did not."));
+            return new AndConstraint<CommandResultAssertions>(this);
+        }
+
+        internal AndConstraint<CommandResultAssertions> Pass()
+        {
+            Execute.Assertion.ForCondition(_commandResult.ExitCode == 0)
+                .FailWith(AppendDiagnosticsTo($"Expected command to pass but it did not."));
+            return new AndConstraint<CommandResultAssertions>(this);
+        }
+
+        internal AndConstraint<CommandResultAssertions> Fail()
+        {
+            Execute.Assertion.ForCondition(_commandResult.ExitCode != 0)
+                .FailWith(AppendDiagnosticsTo($"Expected command to fail but it did not."));
+            return new AndConstraint<CommandResultAssertions>(this);
+        }
+
+        internal AndConstraint<CommandResultAssertions> HaveStdOut()
+        {
+            Execute.Assertion.ForCondition(!string.IsNullOrEmpty(_commandResult.StdOut))
+                .FailWith(AppendDiagnosticsTo("Command did not output anything to stdout"));
+            return new AndConstraint<CommandResultAssertions>(this);
+        }
+
+        internal AndConstraint<CommandResultAssertions> HaveStdOut(string expectedOutput)
+        {
+            if (_commandResult.StdOut is null)
+            {
+                throw new InvalidOperationException("StdOut for the command was not captured");
+            }
+            Execute.Assertion.ForCondition(_commandResult.StdOut.Equals(expectedOutput, StringComparison.Ordinal))
+                .FailWith(AppendDiagnosticsTo($"Command did not output with Expected Output. Expected: {expectedOutput}"));
+            return new AndConstraint<CommandResultAssertions>(this);
+        }
+
+        internal AndConstraint<CommandResultAssertions> HaveStdOutContaining(string pattern)
+        {
+            if (_commandResult.StdOut is null)
+            {
+                throw new InvalidOperationException("StdOut for the command was not captured");
+            }
+            Execute.Assertion.ForCondition(_commandResult.StdOut.Contains(pattern))
+                .FailWith(AppendDiagnosticsTo($"The command output did not contain expected result: {pattern}{Environment.NewLine}"));
+            return new AndConstraint<CommandResultAssertions>(this);
+        }
+
+        internal AndConstraint<CommandResultAssertions> HaveStdOutContaining(Func<string, bool> predicate, string description = "")
+        {
+            if (_commandResult.StdOut is null)
+            {
+                throw new InvalidOperationException("StdOut for the command was not captured");
+            }
+            Execute.Assertion.ForCondition(predicate(_commandResult.StdOut))
+                .FailWith(AppendDiagnosticsTo($"The command output did not contain expected result: {description} {Environment.NewLine}"));
+            return new AndConstraint<CommandResultAssertions>(this);
+        }
+
+        internal AndConstraint<CommandResultAssertions> NotHaveStdOutContaining(string pattern)
+        {
+            if (_commandResult.StdOut is null)
+            {
+                throw new InvalidOperationException("StdOut for the command was not captured");
+            }
+            Execute.Assertion.ForCondition(!_commandResult.StdOut.Contains(pattern))
+                .FailWith(AppendDiagnosticsTo($"The command output contained a result it should not have contained: {pattern}{Environment.NewLine}"));
+            return new AndConstraint<CommandResultAssertions>(this);
+        }
+
+        internal AndConstraint<CommandResultAssertions> HaveStdOutContainingIgnoreSpaces(string pattern)
+        {
+            if (_commandResult.StdOut is null)
+            {
+                throw new InvalidOperationException("StdOut for the command was not captured");
+            }
+            string commandResultNoSpaces = _commandResult.StdOut.Replace(" ", string.Empty);
+
+            Execute.Assertion
+                .ForCondition(commandResultNoSpaces.Contains(pattern))
+                .FailWith(AppendDiagnosticsTo($"The command output did not contain expected result: {pattern}{Environment.NewLine}"));
+
+            return new AndConstraint<CommandResultAssertions>(this);
+        }
+
+        internal AndConstraint<CommandResultAssertions> HaveStdOutContainingIgnoreCase(string pattern)
+        {
+            if (_commandResult.StdOut is null)
+            {
+                throw new InvalidOperationException("StdOut for the command was not captured");
+            }
+            Execute.Assertion.ForCondition(_commandResult.StdOut.Contains(pattern, StringComparison.OrdinalIgnoreCase))
+                .FailWith(AppendDiagnosticsTo($"The command output did not contain expected result (ignoring case): {pattern}{Environment.NewLine}"));
+            return new AndConstraint<CommandResultAssertions>(this);
+        }
+
+        internal AndConstraint<CommandResultAssertions> HaveStdOutMatching(string pattern, RegexOptions options = RegexOptions.None)
+        {
+            if (_commandResult.StdOut is null)
+            {
+                throw new InvalidOperationException("StdOut for the command was not captured");
+            }
+            Execute.Assertion.ForCondition(Regex.Match(_commandResult.StdOut, pattern, options).Success)
+                .FailWith(AppendDiagnosticsTo($"Matching the command output failed. Pattern: {pattern}{Environment.NewLine}"));
+            return new AndConstraint<CommandResultAssertions>(this);
+        }
+
+        internal AndConstraint<CommandResultAssertions> NotHaveStdOutMatching(string pattern, RegexOptions options = RegexOptions.None)
+        {
+            if (_commandResult.StdOut is null)
+            {
+                throw new InvalidOperationException("StdOut for the command was not captured");
+            }
+            Execute.Assertion.ForCondition(!Regex.Match(_commandResult.StdOut, pattern, options).Success)
+                .FailWith(AppendDiagnosticsTo($"The command output matched a pattern it should not have. Pattern: {pattern}{Environment.NewLine}"));
+            return new AndConstraint<CommandResultAssertions>(this);
+        }
+
+        internal AndConstraint<CommandResultAssertions> HaveStdErr()
+        {
+            if (_commandResult.StdErr is null)
+            {
+                throw new InvalidOperationException("StdOut for the command was not captured");
+            }
+            Execute.Assertion.ForCondition(!string.IsNullOrEmpty(_commandResult.StdErr))
+                .FailWith(AppendDiagnosticsTo("Command did not output anything to StdErr."));
+            return new AndConstraint<CommandResultAssertions>(this);
+        }
+
+        internal AndConstraint<CommandResultAssertions> HaveStdErr(string expectedOutput)
+        {
+            if (_commandResult.StdErr is null)
+            {
+                throw new InvalidOperationException("StdErr for the command was not captured");
+            }
+            Execute.Assertion.ForCondition(_commandResult.StdErr.Equals(expectedOutput, StringComparison.Ordinal))
+                .FailWith(AppendDiagnosticsTo($"Command did not output the expected output to StdErr.{Environment.NewLine}Expected: {expectedOutput}{Environment.NewLine}Actual:   {_commandResult.StdErr}"));
+            return new AndConstraint<CommandResultAssertions>(this);
+        }
+
+        internal AndConstraint<CommandResultAssertions> HaveStdErrContaining(string pattern)
+        {
+            if (_commandResult.StdErr is null)
+            {
+                throw new InvalidOperationException("StdErr for the command was not captured");
+            }
+            Execute.Assertion.ForCondition(_commandResult.StdErr.Contains(pattern))
+                .FailWith(AppendDiagnosticsTo($"The command error output did not contain expected result: {pattern}{Environment.NewLine}"));
+            return new AndConstraint<CommandResultAssertions>(this);
+        }
+
+        internal AndConstraint<CommandResultAssertions> NotHaveStdErrContaining(string pattern)
+        {
+            if (_commandResult.StdErr is null)
+            {
+                throw new InvalidOperationException("StdErr for the command was not captured");
+            }
+            Execute.Assertion.ForCondition(!_commandResult.StdErr.Contains(pattern))
+                .FailWith(AppendDiagnosticsTo($"The command error output contained a result it should not have contained: {pattern}{Environment.NewLine}"));
+            return new AndConstraint<CommandResultAssertions>(this);
+        }
+
+        internal AndConstraint<CommandResultAssertions> HaveStdErrMatching(string pattern, RegexOptions options = RegexOptions.None)
+        {
+            if (_commandResult.StdErr is null)
+            {
+                throw new InvalidOperationException("StdErr for the command was not captured");
+            }
+            Execute.Assertion.ForCondition(Regex.Match(_commandResult.StdErr, pattern, options).Success)
+                .FailWith(AppendDiagnosticsTo($"Matching the command error output failed. Pattern: {pattern}{Environment.NewLine}"));
+            return new AndConstraint<CommandResultAssertions>(this);
+        }
+
+        internal AndConstraint<CommandResultAssertions> NotHaveStdOut()
+        {
+            if (_commandResult.StdOut is null)
+            {
+                throw new InvalidOperationException("StdOut for the command was not captured");
+            }
+            Execute.Assertion.ForCondition(string.IsNullOrEmpty(_commandResult.StdOut))
+                .FailWith(AppendDiagnosticsTo($"Expected command to not output to stdout but it was not:"));
+            return new AndConstraint<CommandResultAssertions>(this);
+        }
+
+        internal AndConstraint<CommandResultAssertions> NotHaveStdErr()
+        {
+            if (_commandResult.StdErr is null)
+            {
+                throw new InvalidOperationException("StdErr for the command was not captured");
+            }
+            Execute.Assertion.ForCondition(string.IsNullOrEmpty(_commandResult.StdErr))
+                .FailWith(AppendDiagnosticsTo("Expected command to not output to stderr but it was not:"));
+            return new AndConstraint<CommandResultAssertions>(this);
+        }
+
+        internal AndConstraint<CommandResultAssertions> HaveSkippedProjectCompilation(string skippedProject, string frameworkFullName)
+        {
+            _commandResult.StdOut.Should().Contain($"Project {skippedProject} ({frameworkFullName}) was previously compiled. Skipping compilation.");
+
+            return new AndConstraint<CommandResultAssertions>(this);
+        }
+
+        internal AndConstraint<CommandResultAssertions> HaveCompiledProject(string compiledProject, string frameworkFullName)
+        {
+            _commandResult.StdOut.Should().Contain($"Project {compiledProject} ({frameworkFullName}) will be compiled");
+
+            return new AndConstraint<CommandResultAssertions>(this);
+        }
+
+        private string AppendDiagnosticsTo(string s)
+        {
+            return (s + $"{Environment.NewLine}" +
+                       $"File Name: {_commandResult.StartInfo.FileName}{Environment.NewLine}" +
+                       $"Arguments: {_commandResult.StartInfo.Arguments}{Environment.NewLine}" +
+                       $"Exit Code: {_commandResult.ExitCode}{Environment.NewLine}" +
+                       $"StdOut:{Environment.NewLine}{_commandResult.StdOut}{Environment.NewLine}" +
+                       $"StdErr:{Environment.NewLine}{_commandResult.StdErr}{Environment.NewLine}")
+                       //escape curly braces for String.Format
+                       .Replace("{", "{{").Replace("}", "}}");
+        }
+    }
+}

--- a/Test.Microsoft.NET.Build.Containers.Filesystem/CommandUtils/CommandResultExtensions.cs
+++ b/Test.Microsoft.NET.Build.Containers.Filesystem/CommandUtils/CommandResultExtensions.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.CommandUtils
+{
+    internal static class CommandResultExtensions
+    {
+        internal static CommandResultAssertions Should(this CommandResult commandResult)
+        {
+            return new CommandResultAssertions(commandResult);
+        }
+    }
+}

--- a/Test.Microsoft.NET.Build.Containers.Filesystem/CommandUtils/DotnetCommand.cs
+++ b/Test.Microsoft.NET.Build.Containers.Filesystem/CommandUtils/DotnetCommand.cs
@@ -1,0 +1,42 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.CommandUtils
+{
+    internal class DotnetCommand : TestCommand
+    {
+        private string _executableFilePath = "dotnet";
+
+        internal DotnetCommand(TestContext log, string subcommand, params string[] args) : base(log)
+        {
+            Arguments.Add(subcommand);
+            Arguments.AddRange(args);
+        }
+
+        internal DotnetCommand WithoutTelemetry()
+        {
+            WithEnvironmentVariable("DOTNET_CLI_TELEMETRY_OPTOUT", "true");
+            return this;
+        }
+
+        internal DotnetCommand WithCustomExecutablePath(string? executableFilePath)
+        {
+            if (!string.IsNullOrEmpty(executableFilePath))
+            {
+                _executableFilePath = executableFilePath;
+            }
+            return this;
+        }
+
+        private protected override SdkCommandSpec CreateCommand(IEnumerable<string> args)
+        {
+            var sdkCommandSpec = new SdkCommandSpec()
+            {
+                FileName = _executableFilePath,
+                Arguments = args.ToList(),
+                WorkingDirectory = WorkingDirectory
+            };
+            return sdkCommandSpec;
+        }
+    }
+}

--- a/Test.Microsoft.NET.Build.Containers.Filesystem/CommandUtils/NativeMethods.cs
+++ b/Test.Microsoft.NET.Build.Containers.Filesystem/CommandUtils/NativeMethods.cs
@@ -1,0 +1,96 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+namespace Microsoft.DotNet.CommandUtils
+{
+    internal static class NativeMethods
+    {
+        internal static class Windows
+        {
+            internal const int ProcessBasicInformation = 0;
+
+            internal enum JobObjectInfoClass : uint
+            {
+                JobObjectExtendedLimitInformation = 9,
+            }
+
+            [Flags]
+            internal enum JobObjectLimitFlags : uint
+            {
+                JobObjectLimitKillOnJobClose = 0x2000,
+            }
+
+            [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+            internal static extern SafeWaitHandle CreateJobObjectW(IntPtr lpJobAttributes, string? lpName);
+
+            [DllImport("kernel32.dll", SetLastError = true)]
+            internal static extern bool SetInformationJobObject(IntPtr hJob, JobObjectInfoClass jobObjectInformationClass, IntPtr lpJobObjectInformation, uint cbJobObjectInformationLength);
+
+            [DllImport("kernel32.dll", SetLastError = true)]
+            internal static extern bool AssignProcessToJobObject(IntPtr hJob, IntPtr hProcess);
+
+            [DllImport("kernel32.dll", CharSet = CharSet.Auto)]
+            [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+            internal static extern IntPtr GetCommandLine();
+
+            [StructLayout(LayoutKind.Sequential)]
+            internal struct JobObjectBasicLimitInformation
+            {
+                public long PerProcessUserTimeLimit;
+                public long PerJobUserTimeLimit;
+                public JobObjectLimitFlags LimitFlags;
+                public UIntPtr MinimumWorkingSetSize;
+                public UIntPtr MaximumWorkingSetSize;
+                public uint ActiveProcessLimit;
+                public UIntPtr Affinity;
+                public uint PriorityClass;
+                public uint SchedulingClass;
+            }
+
+            [StructLayout(LayoutKind.Sequential)]
+            internal struct IoCounters
+            {
+                public ulong ReadOperationCount;
+                public ulong WriteOperationCount;
+                public ulong OtherOperationCount;
+                public ulong ReadTransferCount;
+                public ulong WriteTransferCount;
+                public ulong OtherTransferCount;
+            }
+
+            [StructLayout(LayoutKind.Sequential)]
+            internal struct JobObjectExtendedLimitInformation
+            {
+                public JobObjectBasicLimitInformation BasicLimitInformation;
+                public IoCounters IoInfo;
+                public UIntPtr ProcessMemoryLimit;
+                public UIntPtr JobMemoryLimit;
+                public UIntPtr PeakProcessMemoryUsed;
+                public UIntPtr PeakJobMemoryUsed;
+            }
+
+            [StructLayout(LayoutKind.Sequential)]
+            internal struct PROCESS_BASIC_INFORMATION
+            {
+                public uint ExitStatus;
+                public IntPtr PebBaseAddress;
+                public UIntPtr AffinityMask;
+                public int BasePriority;
+                public UIntPtr UniqueProcessId;
+                public UIntPtr InheritedFromUniqueProcessId;
+            }
+        }
+
+        internal static class Posix
+        {
+            internal const int SIGINT = 2;
+            internal const int SIGTERM = 15;
+
+            [DllImport("libc", SetLastError = true)]
+            internal static extern int kill(int pid, int sig);
+        }
+    }
+}

--- a/Test.Microsoft.NET.Build.Containers.Filesystem/CommandUtils/ProcessReaper.cs
+++ b/Test.Microsoft.NET.Build.Containers.Filesystem/CommandUtils/ProcessReaper.cs
@@ -1,0 +1,194 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+namespace Microsoft.DotNet.CommandUtils
+{
+    /// <summary>
+    /// Responsible for reaping a target process if the current process terminates.
+    /// </summary>
+    /// <remarks>
+    /// On Windows, a job object will be used to ensure the termination of the target
+    /// process (and its tree) even if the current process is rudely terminated.
+    ///
+    /// On POSIX systems, the reaper will handle SIGTERM and attempt to forward the
+    /// signal to the target process only.
+    ///
+    /// The reaper also suppresses SIGINT in the current process to allow the target
+    /// process to handle the signal.
+    /// </remarks>
+    internal class ProcessReaper : IDisposable
+    {
+        private readonly Process _process;
+        private SafeWaitHandle? _job;
+        private Mutex? _shutdownMutex;
+
+        /// <summary>
+        /// Creates a new process reaper.
+        /// </summary>
+        /// <param name="process">The target process to reap if the current process terminates. The process should not yet be started.</param>
+        public ProcessReaper(Process process)
+        {
+            _process = process;
+
+            // The tests need the event handlers registered prior to spawning the child to prevent a race
+            // where the child writes output the test expects before the intermediate dotnet process
+            // has registered the event handlers to handle the signals the tests will generate.
+            Console.CancelKeyPress += HandleCancelKeyPress;
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                _shutdownMutex = new Mutex();
+                AppDomain.CurrentDomain.ProcessExit += HandleProcessExit;
+            }
+        }
+
+        /// <summary>
+        /// Call to notify the reaper that the process has started.
+        /// </summary>
+        public void NotifyProcessStarted()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                // Limit the use of job objects to versions of Windows that support nested jobs (i.e. Windows 8/2012 or later).
+                // Ideally, we would check for some new API export or OS feature instead of the OS version,
+                // but nested jobs are transparently implemented with respect to the Job Objects API.
+                // Note: Windows 8.1 and later may report as Windows 8 (see https://docs.microsoft.com/en-us/windows/desktop/sysinfo/operating-system-version).
+                //       However, for the purpose of this check that is still sufficient.
+                if (Environment.OSVersion.Version.Major > 6 ||
+                   (Environment.OSVersion.Version.Major == 6 && Environment.OSVersion.Version.Minor >= 2))
+                {
+                    _job = AssignProcessToJobObject(_process.Handle);
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                if (_job != null)
+                {
+                    // Clear the kill on close flag because the child process terminated successfully
+                    // If this fails, then we have no choice but to terminate any remaining processes in the job
+                    SetKillOnJobClose(_job.DangerousGetHandle(), false);
+
+                    _job.Dispose();
+                    _job = null;
+                }
+            }
+            else
+            {
+                AppDomain.CurrentDomain.ProcessExit -= HandleProcessExit;
+
+                // If there's been a shutdown via the process exit handler,
+                // this will block the current thread so we don't race with the CLR shutdown
+                // from the signal handler.
+                if (_shutdownMutex != null)
+                {
+                    _shutdownMutex.WaitOne();
+                    _shutdownMutex.ReleaseMutex();
+                    _shutdownMutex.Dispose();
+                    _shutdownMutex = null;
+                }
+            }
+
+            Console.CancelKeyPress -= HandleCancelKeyPress;
+        }
+
+        private static void HandleCancelKeyPress(object? sender, ConsoleCancelEventArgs e)
+        {
+            // Ignore SIGINT/SIGQUIT so that the process can handle the signal
+            e.Cancel = true;
+        }
+
+        private static SafeWaitHandle? AssignProcessToJobObject(IntPtr process)
+        {
+            var job = NativeMethods.Windows.CreateJobObjectW(IntPtr.Zero, null);
+            if (job == null || job.IsInvalid)
+            {
+                return null;
+            }
+
+            if (!SetKillOnJobClose(job.DangerousGetHandle(), true))
+            {
+                job.Dispose();
+                return null;
+            }
+
+            if (!NativeMethods.Windows.AssignProcessToJobObject(job.DangerousGetHandle(), process))
+            {
+                job.Dispose();
+                return null;
+            }
+
+            return job;
+        }
+
+        private static bool SetKillOnJobClose(IntPtr job, bool value)
+        {
+            var information = new NativeMethods.Windows.JobObjectExtendedLimitInformation
+            {
+                BasicLimitInformation = new NativeMethods.Windows.JobObjectBasicLimitInformation
+                {
+                    LimitFlags = value ? NativeMethods.Windows.JobObjectLimitFlags.JobObjectLimitKillOnJobClose : 0
+                }
+            };
+
+            var length = Marshal.SizeOf(typeof(NativeMethods.Windows.JobObjectExtendedLimitInformation));
+            var informationPtr = Marshal.AllocHGlobal(length);
+
+            try
+            {
+                Marshal.StructureToPtr(information, informationPtr, false);
+
+                if (!NativeMethods.Windows.SetInformationJobObject(
+                    job,
+                    NativeMethods.Windows.JobObjectInfoClass.JobObjectExtendedLimitInformation,
+                    informationPtr,
+                    (uint)length))
+                {
+                    return false;
+                }
+
+                return true;
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(informationPtr);
+            }
+        }
+
+        private void HandleProcessExit(object? sender, EventArgs args)
+        {
+            int processId;
+            try
+            {
+                processId = _process.Id;
+            }
+            catch (InvalidOperationException)
+            {
+                // The process hasn't started yet; nothing to signal
+                return;
+            }
+
+            // Take ownership of the shutdown mutex; this will ensure that the other
+            // thread also waiting on the process to exit won't complete CLR shutdown before
+            // this one does.
+            _shutdownMutex?.WaitOne();
+
+            if (!_process.WaitForExit(0) && NativeMethods.Posix.kill(processId, NativeMethods.Posix.SIGTERM) != 0)
+            {
+                // Couldn't send the signal, don't wait
+                return;
+            }
+
+            // If SIGTERM was ignored by the target, then we'll still wait
+            _process.WaitForExit();
+
+            Environment.ExitCode = _process.ExitCode;
+        }
+    }
+}

--- a/Test.Microsoft.NET.Build.Containers.Filesystem/CommandUtils/SdkCommandSpec.cs
+++ b/Test.Microsoft.NET.Build.Containers.Filesystem/CommandUtils/SdkCommandSpec.cs
@@ -1,0 +1,62 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+
+namespace Microsoft.DotNet.CommandUtils
+{
+    internal class SdkCommandSpec
+    {
+        public string? FileName { get; set; }
+
+        public List<string> Arguments { get; set; } = new List<string>();
+
+        public Dictionary<string, string> Environment { get; set; } = new Dictionary<string, string>();
+
+        public List<string> EnvironmentToRemove { get; } = new List<string>();
+
+        public string? WorkingDirectory { get; set; }
+
+        public Command ToCommand()
+        {
+            var process = new Process()
+            {
+                StartInfo = ToProcessStartInfo()
+            };
+            var ret = new Command(process, trimtrailingNewlines: true);
+            return ret;
+        }
+
+        public ProcessStartInfo ToProcessStartInfo()
+        {
+            var ret = new ProcessStartInfo
+            {
+                FileName = FileName,
+                Arguments = EscapeArgs(),
+                UseShellExecute = false
+            };
+            foreach (var kvp in Environment)
+            {
+                ret.Environment[kvp.Key] = kvp.Value;
+            }
+            foreach (var envToRemove in EnvironmentToRemove)
+            {
+                ret.Environment.Remove(envToRemove);
+            }
+
+            if (WorkingDirectory != null)
+            {
+                ret.WorkingDirectory = WorkingDirectory;
+            }
+
+            return ret;
+        }
+
+        private string EscapeArgs()
+        {
+            //  Note: this doesn't handle invoking .cmd files via "cmd /c" on Windows, which probably won't be necessary here
+            //  If it is, refer to the code in WindowsExePreferredCommandSpecFactory in Microsoft.DotNet.Cli.Utils
+            return ArgumentEscaper.EscapeAndConcatenateArgArrayForProcessStart(Arguments);
+        }
+    }
+}

--- a/Test.Microsoft.NET.Build.Containers.Filesystem/CommandUtils/StreamForwarder.cs
+++ b/Test.Microsoft.NET.Build.Containers.Filesystem/CommandUtils/StreamForwarder.cs
@@ -1,0 +1,126 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text;
+
+namespace Microsoft.DotNet.CommandUtils
+{
+    internal sealed class StreamForwarder
+    {
+        private const char FlushBuilderCharacter = '\n';
+        private static readonly char[] IgnoreCharacters = new char[] { '\r' };
+
+        private StringBuilder? _builder;
+        private StringWriter? _capture;
+        private Action<string>? _writeLine;
+        private bool _trimTrailingCapturedNewline;
+
+        public string? CapturedOutput
+        {
+            get
+            {
+                string? capture = _capture?.GetStringBuilder()?.ToString();
+                if (_trimTrailingCapturedNewline)
+                {
+                    capture = capture?.TrimEnd('\r', '\n');
+                }
+                return capture;
+            }
+        }
+
+        public StreamForwarder Capture(bool trimTrailingNewline = false)
+        {
+            ThrowIfCaptureSet();
+
+            _capture = new StringWriter();
+            _trimTrailingCapturedNewline = trimTrailingNewline;
+
+            return this;
+        }
+
+        public StreamForwarder ForwardTo(Action<string> writeLine)
+        {
+            ThrowIfNull(writeLine);
+
+            ThrowIfForwarderSet();
+
+            _writeLine = writeLine;
+
+            return this;
+        }
+
+        public Task BeginRead(TextReader reader) => Task.Run(() => Read(reader));
+
+        public void Read(TextReader reader)
+        {
+            int bufferSize = 1;
+            char currentCharacter;
+
+            char[] buffer = new char[bufferSize];
+            _builder = new StringBuilder();
+
+            // Using Read with buffer size 1 to prevent looping endlessly
+            // like we would when using Read() with no buffer
+            while ((_ = reader.Read(buffer, 0, bufferSize)) > 0)
+            {
+                currentCharacter = buffer[0];
+
+                if (currentCharacter == FlushBuilderCharacter)
+                {
+                    WriteBuilder();
+                }
+                else if (!IgnoreCharacters.Contains(currentCharacter))
+                {
+                    _ = _builder.Append(currentCharacter);
+                }
+            }
+
+            // Flush anything else when the stream is closed
+            // Which should only happen if someone used console.Write
+            if (_builder.Length > 0)
+            {
+                WriteBuilder();
+            }
+        }
+
+        private void WriteBuilder()
+        {
+            WriteLine(_builder?.ToString());
+            _ = (_builder?.Clear());
+        }
+
+        private void WriteLine(string? str)
+        {
+            _capture?.WriteLine(str);
+
+            if (_writeLine != null && str != null)
+            {
+                _writeLine(str);
+            }
+        }
+
+        private void ThrowIfNull(object obj)
+        {
+            if (obj == null)
+            {
+                throw new ArgumentNullException(nameof(obj));
+            }
+        }
+
+        private void ThrowIfForwarderSet()
+        {
+            if (_writeLine != null)
+            {
+                throw new InvalidOperationException("WriteLine forwarder set previously");
+            }
+        }
+
+        private void ThrowIfCaptureSet()
+        {
+            if (_capture != null)
+            {
+                throw new InvalidOperationException("Already capturing stream!");
+            }
+        }
+    }
+}

--- a/Test.Microsoft.NET.Build.Containers.Filesystem/CommandUtils/TestCommand.cs
+++ b/Test.Microsoft.NET.Build.Containers.Filesystem/CommandUtils/TestCommand.cs
@@ -1,0 +1,135 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+
+namespace Microsoft.DotNet.CommandUtils
+{
+    internal abstract class TestCommand
+    {
+        private readonly TestContext? _log;
+
+        protected TestCommand(TestContext? log)
+        {
+            _log = log;
+        }
+
+        internal string? WorkingDirectory { get; set; }
+
+        internal List<string> Arguments { get; set; } = new List<string>();
+
+        internal List<string> EnvironmentToRemove { get; } = new List<string>();
+
+        //  These only work via Execute(), not when using GetProcessStartInfo()
+        internal Action<string>? CommandOutputHandler { get; set; }
+
+        internal Action<Process>? ProcessStartedHandler { get; set; }
+
+        protected Dictionary<string, string> Environment { get; set; } = new Dictionary<string, string>();
+
+        internal TestCommand WithEnvironmentVariable(string name, string value)
+        {
+            Environment[name] = value;
+            return this;
+        }
+
+        internal TestCommand WithEnvironmentVariables(IReadOnlyDictionary<string, string>? variables)
+        {
+            if (variables != null)
+            {
+                foreach (KeyValuePair<string, string> pair in variables)
+                {
+                    Environment[pair.Key] = pair.Value;
+                }
+            }
+            return this;
+        }
+
+        internal TestCommand WithWorkingDirectory(string workingDirectory)
+        {
+            WorkingDirectory = workingDirectory;
+            return this;
+        }
+
+        internal TestCommand WithNoUpdateCheck()
+        {
+            Arguments.Add("--no-update-check");
+            return this;
+        }
+
+        internal ProcessStartInfo GetProcessStartInfo(params string[] args)
+        {
+            SdkCommandSpec commandSpec = CreateCommandSpec(args);
+
+            var psi = commandSpec.ToProcessStartInfo();
+
+            return psi;
+        }
+
+        internal CommandResult Execute(params string[] args)
+        {
+            IEnumerable<string> enumerableArgs = args;
+            return Execute(enumerableArgs);
+        }
+
+        internal virtual CommandResult Execute(IEnumerable<string> args)
+        {
+            Command command = CreateCommandSpec(args)
+                .ToCommand()
+                .CaptureStdOut()
+                .CaptureStdErr();
+
+            if (CommandOutputHandler != null)
+            {
+                command.OnOutputLine(CommandOutputHandler);
+            }
+
+            var result = command.Execute(ProcessStartedHandler);
+
+            _log?.WriteLine($"> {result.StartInfo.FileName} {result.StartInfo.Arguments}");
+            _log?.WriteLine(result.StdOut);
+
+            if (!string.IsNullOrEmpty(result.StdErr))
+            {
+                _log?.WriteLine(string.Empty);
+                _log?.WriteLine("StdErr:");
+                _log?.WriteLine(result.StdErr);
+            }
+
+            if (result.ExitCode != 0)
+            {
+                _log?.WriteLine($"Exit Code: {result.ExitCode}");
+            }
+
+            return result;
+        }
+
+        private protected abstract SdkCommandSpec CreateCommand(IEnumerable<string> args);
+
+        private SdkCommandSpec CreateCommandSpec(IEnumerable<string> args)
+        {
+            var commandSpec = CreateCommand(args);
+            foreach (var kvp in Environment)
+            {
+                commandSpec.Environment[kvp.Key] = kvp.Value;
+            }
+
+            foreach (var envToRemove in EnvironmentToRemove)
+            {
+                commandSpec.EnvironmentToRemove.Add(envToRemove);
+            }
+
+            if (WorkingDirectory != null)
+            {
+                commandSpec.WorkingDirectory = WorkingDirectory;
+            }
+
+            if (Arguments.Any())
+            {
+                commandSpec.Arguments = Arguments.Concat(commandSpec.Arguments).ToList();
+            }
+
+            return commandSpec;
+        }
+    }
+}

--- a/Test.Microsoft.NET.Build.Containers.Filesystem/DockerRegistryManager.cs
+++ b/Test.Microsoft.NET.Build.Containers.Filesystem/DockerRegistryManager.cs
@@ -1,5 +1,7 @@
 ﻿using System.Diagnostics;
+using System.Reflection.PortableExecutable;
 using Microsoft.Build.Locator;
+using Microsoft.DotNet.CommandUtils;
 
 namespace Test.Microsoft.NET.Build.Containers.Filesystem;
 
@@ -11,49 +13,30 @@ public class DockerRegistryManager
     public const string Net7ImageTag = "7.0";
     public const string LocalRegistry = "localhost:5010";
     public const string FullyQualifiedBaseImageDefault = $"{BaseImageSource}{BaseImage}:{Net6ImageTag}";
-    private static string s_registryContainerId;
-
-    private static void Exec(string command, string args) {
-        var psi = new ProcessStartInfo(command, args)
-        {
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-        };
-        var proc = Process.Start(psi);
-        Assert.IsNotNull(proc);
-        proc.WaitForExit();
-        var stdout = proc.StandardOutput.ReadToEnd();
-        var stderr = proc.StandardError.ReadToEnd();
-        var message = $"StdOut:\n{stdout}\nStdErr:\n{stderr}";
-        Assert.AreEqual(0, proc.ExitCode, message);
-    }
+    private static string? s_registryContainerId;
 
     [AssemblyInitialize]
     public static void StartAndPopulateDockerRegistry(TestContext context)
     {
         context.WriteLine("Spawning local registry");
-        ProcessStartInfo startRegistry = new("docker", "run --rm --publish 5010:5000 --detach registry:2")
-        {
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-        };
-
-        using Process registryProcess = Process.Start(startRegistry);
-        Assert.IsNotNull(registryProcess);
-        string registryContainerId = registryProcess.StandardOutput.ReadLine();
-        // debugging purposes
-        string everythingElse = registryProcess.StandardOutput.ReadToEnd();
-        string errStream = registryProcess.StandardError.ReadToEnd();
-        Assert.IsNotNull(registryContainerId);
-        registryProcess.WaitForExit();
-        Assert.AreEqual(0, registryProcess.ExitCode, $"Could not start Docker registry. Are you running one for manual testing?{Environment.NewLine}{errStream}");
-        s_registryContainerId = registryContainerId;
+        CommandResult processResult = new BasicCommand(context, "docker", "run", "--rm", "--publish", "5010:5000", "--detach", "registry:2").Execute();
+        processResult.Should().Pass().And.HaveStdOut();
+        using var reader = new StringReader(processResult.StdOut!);
+        s_registryContainerId = reader.ReadLine();
 
         foreach (var tag in new[] { Net6ImageTag, Net7ImageTag })
         {
-            Exec("docker", $"pull {BaseImageSource}{BaseImage}:{tag}");
-            Exec("docker", $"tag {BaseImageSource}{BaseImage}:{tag} {LocalRegistry}/{BaseImage}:{tag}");
-            Exec("docker", $"push {LocalRegistry}/{BaseImage}:{tag}");
+            new BasicCommand(context, "docker", "pull", $"{BaseImageSource}{BaseImage}:{tag}")
+                .Execute()
+                .Should().Pass();
+
+            new BasicCommand(context, "docker", "tag", $"{BaseImageSource}{BaseImage}:{tag}", $"{LocalRegistry}/{BaseImage}:{tag}")
+                .Execute()
+                .Should().Pass();
+
+            new BasicCommand(context, "docker", "push", $"{LocalRegistry}/{BaseImage}:{tag}")
+                .Execute()
+                .Should().Pass();
         }
     }
 
@@ -61,9 +44,8 @@ public class DockerRegistryManager
     {
         Assert.IsNotNull(s_registryContainerId);
 
-        Process shutdownRegistry = Process.Start("docker", $"stop {s_registryContainerId}");
-        Assert.IsNotNull(shutdownRegistry);
-        shutdownRegistry.WaitForExit();
-        Assert.AreEqual(0, shutdownRegistry.ExitCode);
+        new BasicCommand(null, "docker", "stop", s_registryContainerId)
+            .Execute()
+            .Should().Pass();
     }
 }

--- a/Test.Microsoft.NET.Build.Containers.Filesystem/LayerEndToEnd.cs
+++ b/Test.Microsoft.NET.Build.Containers.Filesystem/LayerEndToEnd.cs
@@ -77,11 +77,11 @@ public class LayerEndToEnd
         }
 
         Assert.AreEqual(Convert.ToHexString(hashBytes), l.Descriptor.Digest.Substring("sha256:".Length), ignoreCase: true);
-        Assert.AreEqual(Convert.ToHexString(uncompressedHashBytes), l.Descriptor.UncompressedDigest.Substring("sha256:".Length), ignoreCase: true);
+        Assert.AreEqual(Convert.ToHexString(uncompressedHashBytes), l.Descriptor.UncompressedDigest?.Substring("sha256:".Length), ignoreCase: true);
     }
 
-    TransientTestFolder testSpecificArtifactRoot;
-    string priorArtifactRoot;
+    TransientTestFolder? testSpecificArtifactRoot;
+    string? priorArtifactRoot;
 
     [TestInitialize]
     public void TestInitialize()

--- a/Test.Microsoft.NET.Build.Containers.Filesystem/ProjectInitializer.cs
+++ b/Test.Microsoft.NET.Build.Containers.Filesystem/ProjectInitializer.cs
@@ -6,7 +6,7 @@ using Microsoft.Build.Locator;
 namespace Test.Microsoft.NET.Build.Containers;
 
 public static class ProjectInitializer {
-    private static string CombinedTargetsLocation;
+    private static string? CombinedTargetsLocation;
 
     private static string CombineFiles(string propsFile, string targetsFile)
     {
@@ -16,7 +16,9 @@ public static class ProjectInitializer {
         combinedContent.AddRange(propsContent[..^1]);
         combinedContent.AddRange(targetsContent[1..]);
         var tempTargetLocation = Path.Combine(Path.GetTempPath(), "Containers", "Microsoft.NET.Build.Containers.targets");
-        Directory.CreateDirectory(Path.GetDirectoryName(tempTargetLocation));
+        string? directoryName = Path.GetDirectoryName(tempTargetLocation);
+        Assert.IsNotNull(directoryName);
+        Directory.CreateDirectory(directoryName);
         File.WriteAllLines(tempTargetLocation, combinedContent);
         return tempTargetLocation;
     }

--- a/Test.Microsoft.NET.Build.Containers.Filesystem/RegistryTests.cs
+++ b/Test.Microsoft.NET.Build.Containers.Filesystem/RegistryTests.cs
@@ -15,12 +15,13 @@ public class RegistryTests
     {
         Registry registry = new Registry(ContainerHelpers.TryExpandRegistryToUri(DockerRegistryManager.LocalRegistry));
 
+        string dotnetRoot = ToolsetUtils.GetDotNetPath();
         // TODO: The DOTNET_ROOT comes from the test host, but we have no idea what the SDK version is.
-        var ridgraphfile = Path.Combine(Environment.GetEnvironmentVariable("DOTNET_ROOT"), "sdk", "7.0.100", "RuntimeIdentifierGraph.json");
+        var ridgraphfile = Path.Combine(dotnetRoot, "sdk", "7.0.100", "RuntimeIdentifierGraph.json");
 
         // Don't need rid graph for local registry image pulls - since we're only pushing single image manifests (not manifest lists)
         // as part of our setup, we could put literally anything in here. The file at the passed-in path would only get read when parsing manifests lists.
-        Image downloadedImage = await registry.GetImageManifest(DockerRegistryManager.BaseImage, DockerRegistryManager.Net6ImageTag, "linux-x64", ridgraphfile);
+        Image? downloadedImage = await registry.GetImageManifest(DockerRegistryManager.BaseImage, DockerRegistryManager.Net6ImageTag, "linux-x64", ridgraphfile);
 
         Assert.IsNotNull(downloadedImage);
     }

--- a/Test.Microsoft.NET.Build.Containers.Filesystem/Test.Microsoft.NET.Build.Containers.Filesystem.csproj
+++ b/Test.Microsoft.NET.Build.Containers.Filesystem/Test.Microsoft.NET.Build.Containers.Filesystem.csproj
@@ -4,9 +4,11 @@
     <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="MSTest.TestAdapter" />
     <PackageReference Include="MSTest.TestFramework" />

--- a/Test.Microsoft.NET.Build.Containers.Filesystem/ToolsetUtils.cs
+++ b/Test.Microsoft.NET.Build.Containers.Filesystem/ToolsetUtils.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Test.Microsoft.NET.Build.Containers.Filesystem
+{
+    internal static class ToolsetUtils
+    {
+        /// <summary>
+        /// Returns the path with installed dotnet.
+        /// Order of processing: 
+        /// - DOTNET_ROOT environment variable
+        /// - DOTNET_INSTALL_DIR environment variable
+        /// - resolving dotnet executable path.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">on unexpected environment result, i.e. common environment variables are not set.</exception>
+        internal static string GetDotNetPath()
+        {
+            string? dotnetRootFromEnvironment = Environment.GetEnvironmentVariable("DOTNET_ROOT");
+            string? dotnetInstallDirFromEnvironment = Environment.GetEnvironmentVariable("DOTNET_INSTALL_DIR");
+
+            if (!string.IsNullOrEmpty(dotnetRootFromEnvironment) && Directory.Exists(dotnetRootFromEnvironment))
+            {
+                return dotnetRootFromEnvironment;
+            }
+            else if (!string.IsNullOrEmpty(dotnetInstallDirFromEnvironment) && Directory.Exists(dotnetInstallDirFromEnvironment))
+            {
+                return dotnetInstallDirFromEnvironment;
+            }
+            string dotnetExePath = ResolveCommand("dotnet");
+            string dotnetRoot = Path.GetDirectoryName(dotnetExePath) ?? throw new InvalidOperationException("dotnet executable is in the root?");
+            if (Directory.Exists(dotnetInstallDirFromEnvironment))
+            {
+                Assert.Fail("'dotnet' was not found.");
+            }
+            return dotnetRoot;
+        }
+
+        private static string ResolveCommand(string command)
+        {
+            char pathSplitChar;
+            string[] extensions = new string[] { string.Empty };
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                string? pathExt = Environment.GetEnvironmentVariable("PATHEXT") ?? throw new InvalidOperationException("PATHEXT is not set.");
+                pathSplitChar = ';';
+                extensions = extensions
+                    .Concat(pathExt.Split(pathSplitChar))
+                    .ToArray();
+            }
+            else
+            {
+                pathSplitChar = ':';
+            }
+
+            string? path = Environment.GetEnvironmentVariable("PATH") ?? throw new InvalidOperationException("PATH is not set.");
+
+            var paths = path.Split(pathSplitChar);
+            string? result = extensions.SelectMany(ext => paths.Select(p => Path.Combine(p, command + ext)))
+                .FirstOrDefault(File.Exists);
+
+            return result ?? throw new InvalidOperationException("Could not resolve path to " + command);
+        }
+    }
+}


### PR DESCRIPTION
- ported command utils from dotnet/sdk (https://github.com/dotnet/sdk/tree/main/src/Tests/Microsoft.NET.TestFramework)
- replaced `Process.Start` with utils - allows better error reporting in first place
- enabled nullables
- added KISS `dotnet` path resolver (inspired by https://github.com/dotnet/sdk/blob/main/src/Tests/Microsoft.NET.TestFramework/ToolsetInfo.cs)