### PR TITLE
Fix Tar writing to include directory records

### DIFF
--- a/Microsoft.NET.Build.Containers/LocalDocker.cs
+++ b/Microsoft.NET.Build.Containers/LocalDocker.cs
@@ -39,7 +39,7 @@ public class LocalDocker
 
     public static async Task WriteImageToStream(Image x, string name, string tag, Stream imageStream)
     {
-        TarWriter writer = new(imageStream, TarEntryFormat.Gnu, leaveOpen: true);
+        using TarWriter writer = new(imageStream, TarEntryFormat.Pax, leaveOpen: true);
 
 
         // Feed each layer tarball into the stream
@@ -67,7 +67,7 @@ public class LocalDocker
 
         using (MemoryStream configStream = new MemoryStream(Encoding.UTF8.GetBytes(x.config.ToJsonString())))
         {
-            GnuTarEntry configEntry = new(TarEntryType.RegularFile, configTarballPath)
+            PaxTarEntry configEntry = new(TarEntryType.RegularFile, configTarballPath)
             {
                 DataStream = configStream
             };
@@ -90,7 +90,7 @@ public class LocalDocker
 
         using (MemoryStream manifestStream = new MemoryStream(Encoding.UTF8.GetBytes(manifestNode.ToJsonString())))
         {
-            GnuTarEntry manifestEntry = new(TarEntryType.RegularFile, "manifest.json")
+            PaxTarEntry manifestEntry = new(TarEntryType.RegularFile, "manifest.json")
             {
                 DataStream = manifestStream
             };

--- a/Test.Microsoft.NET.Build.Containers.Filesystem/LayerEndToEnd.cs
+++ b/Test.Microsoft.NET.Build.Containers.Filesystem/LayerEndToEnd.cs
@@ -23,7 +23,7 @@ public class LayerEndToEnd
         Console.WriteLine(l.Descriptor);
 
         //Assert.AreEqual("application/vnd.oci.image.layer.v1.tar", l.Descriptor.MediaType); // TODO: configurability
-        Assert.IsTrue(l.Descriptor.Size is >= 135 and <= 300, $"'l.Descriptor.Size' should be between 135 and 300, but is {l.Descriptor.Size}"); // TODO: determinism!
+        Assert.IsTrue(l.Descriptor.Size is >= 135 and <= 500, $"'l.Descriptor.Size' should be between 135 and 500, but is {l.Descriptor.Size}"); // TODO: determinism!
         //Assert.AreEqual("sha256:26140bc75f2fcb3bf5da7d3b531d995c93d192837e37df0eb5ca46e2db953124", l.Descriptor.Digest); // TODO: determinism!
 
         VerifyDescriptorInfo(l);


### PR DESCRIPTION
This PR adds the following changes which are all related to https://github.com/dotnet/sdk-container-builds/issues/304 

1. It changes the Tar writing to use `Pax`. This seem to be the default in `docker save`, in [.net](https://github.com/dotnet/runtime/blob/58719ec90b3bbae527dd81685bf8670b993fe8f9/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarWriter.cs#L31) 
2. It ensures that for each file added to the Tar, the respective directory entries are also created. I first though of merging `Layer.FromDirectory` and `Layer.FromFiles` and then traverse the FS tree building the items but I decided against it then. I found some tests aiming to support a list of files from different directories. 
3. Added a missing using to the `TarWriter` writing the file sent to docker. 

On a Windows Setup (Docker Desktop) where Linux Containers and Windows Containers (side-by-side with experimental flag and Hyper-V used) Docker can load **Linux** containers build with sdk-container-builds. 

Building Windows containers unfortunately still fails.


