### PR TITLE
Extend Layer Packaging for Windows Containers

### DIFF
--- a/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
+++ b/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
@@ -48,7 +48,7 @@ public class EndToEndTests
 
         Assert.NotNull(imageBuilder);
 
-        Layer l = Layer.FromDirectory(publishDirectory, "/app");
+        Layer l = Layer.FromDirectory(publishDirectory, "/app", false);
 
         imageBuilder.AddLayer(l);
 
@@ -90,7 +90,7 @@ public class EndToEndTests
             cancellationToken: default).ConfigureAwait(false);
         Assert.NotNull(imageBuilder);
 
-        Layer l = Layer.FromDirectory(publishDirectory, "/app");
+        Layer l = Layer.FromDirectory(publishDirectory, "/app", false);
 
         imageBuilder.AddLayer(l);
 
@@ -293,7 +293,7 @@ public class EndToEndTests
             cancellationToken: default).ConfigureAwait(false);
         Assert.NotNull(imageBuilder);
 
-        Layer l = Layer.FromDirectory(publishDirectory, "/app");
+        Layer l = Layer.FromDirectory(publishDirectory, "/app", false);
 
         imageBuilder.AddLayer(l);
         imageBuilder.SetWorkingDirectory(workingDir);

--- a/Microsoft.NET.Build.Containers/ContainerBuilder.cs
+++ b/Microsoft.NET.Build.Containers/ContainerBuilder.cs
@@ -51,7 +51,7 @@ public static class ContainerBuilder
             WriteIndented = true,
         };
 
-        Layer l = Layer.FromDirectory(folder.FullName, workingDir);
+        Layer l = Layer.FromDirectory(folder.FullName, workingDir, imageBuilder.IsWindows);
 
         imageBuilder.AddLayer(l);
 

--- a/Microsoft.NET.Build.Containers/ImageBuilder.cs
+++ b/Microsoft.NET.Build.Containers/ImageBuilder.cs
@@ -20,6 +20,11 @@ internal sealed class ImageBuilder
     }
 
     /// <summary>
+    /// Gets a value indicating whether the base image is has a Windows operating system.
+    /// </summary>
+    public bool IsWindows => _baseImageConfig.IsWindows;
+
+    /// <summary>
     /// Builds the image configuration <see cref="BuiltImage"/> ready for further processing.
     /// </summary>
     internal BuiltImage Build()

--- a/Microsoft.NET.Build.Containers/ImageConfig.cs
+++ b/Microsoft.NET.Build.Containers/ImageConfig.cs
@@ -32,6 +32,11 @@ internal sealed class ImageConfig
     }
 
     /// <summary>
+    /// Gets a value indicating whether the base image is has a Windows operating system.
+    /// </summary>
+    public bool IsWindows => "windows".Equals(_config["os"]?.GetValue<string>(), StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
     /// Builds in additional configuration and returns updated image configuration in JSON format as string.
     /// </summary>
     internal string BuildConfig()
@@ -43,7 +48,7 @@ internal sealed class ImageConfig
 
         //update creation date
         _config["created"] = DateTime.UtcNow;
-  
+
         config["ExposedPorts"] = CreatePortMap();
         config["Env"] = CreateEnvironmentVariablesMapping();
         config["Labels"] = CreateLabelMap();
@@ -137,7 +142,7 @@ internal sealed class ImageConfig
                 {
                     labels[propertyName] = propertyValue.ToString();
                 }
-            }    
+            }
         }
         return labels;
     }

--- a/Microsoft.NET.Build.Containers/Layer.cs
+++ b/Microsoft.NET.Build.Containers/Layer.cs
@@ -11,6 +11,24 @@ namespace Microsoft.NET.Build.Containers;
 
 internal record struct Layer
 {
+    // NOTE: The SID string below was created using the following snippet. As the code is Windows only we keep the constant
+    // private static string CreateUserOwnerAndGroupSID()
+    // {
+    //     var descriptor = new RawSecurityDescriptor(
+    //         ControlFlags.SelfRelative,
+    //         new SecurityIdentifier(WellKnownSidType.BuiltinUsersSid, null),
+    //         new SecurityIdentifier(WellKnownSidType.BuiltinUsersSid, null),
+    //         null,
+    //         null
+    //     );
+    //
+    //     var raw = new byte[descriptor.BinaryLength];
+    //     descriptor.GetBinaryForm(raw, 0);
+    //     return Convert.ToBase64String(raw);
+    // }
+
+    private const string BuiltinUsersSecurityDescriptor = "AQAAgBQAAAAkAAAAAAAAAAAAAAABAgAAAAAABSAAAAAhAgAAAQIAAAAAAAUgAAAAIQIAAA==";
+
     public Descriptor Descriptor { get; private set; }
 
     public string BackingFile { get; private set; }
@@ -24,7 +42,7 @@ internal record struct Layer
         };
     }
 
-    public static Layer FromDirectory(string directory, string containerPath)
+    public static Layer FromDirectory(string directory, string containerPath, bool isWindowsLayer)
     {
         var fileList =
             new DirectoryInfo(directory)
@@ -34,16 +52,75 @@ internal record struct Layer
                         string destinationPath = Path.Join(containerPath, Path.GetRelativePath(directory, fsi.FullName)).Replace(Path.DirectorySeparatorChar, '/');
                         return (fsi.FullName, destinationPath);
                     });
-        return FromFiles(fileList);
+        return FromFiles(fileList, isWindowsLayer);
     }
 
-    public static Layer FromFiles(IEnumerable<(string path, string containerPath)> fileList)
+    public static Layer FromFiles(IEnumerable<(string path, string containerPath)> fileList, bool isWindowsLayer)
     {
         long fileSize;
         Span<byte> hash = stackalloc byte[SHA256.HashSizeInBytes];
         Span<byte> uncompressedHash = stackalloc byte[SHA256.HashSizeInBytes];
 
+        // this factory helps us creating the Tar entries with the right attributes
+        PaxTarEntry CreateTarEntry(TarEntryType entryType, string containerPath)
+        {
+            var extendedAttributes = new Dictionary<string, string>();
+            if (isWindowsLayer)
+            {
+                // We grant all users access to the application directory
+                // https://github.com/buildpacks/rfcs/blob/main/text/0076-windows-security-identifiers.md
+                extendedAttributes["MSWINDOWS.rawsd"] = BuiltinUsersSecurityDescriptor;
+                return new PaxTarEntry(entryType, containerPath, extendedAttributes);
+            }
+
+            var entry = new PaxTarEntry(entryType, containerPath, extendedAttributes)
+            {
+                Mode = UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+                       UnixFileMode.GroupRead | UnixFileMode.GroupExecute |
+                       UnixFileMode.OtherRead | UnixFileMode.OtherExecute
+            };
+            return entry;
+        }
+
+        string SanitizeContainerPath(string containerPath)
+        {
+            // no leading slashes
+            containerPath = containerPath.TrimStart(PathSeparators);
+
+            // For Windows layers we need to put files into a "Files" directory without drive letter.
+            if (isWindowsLayer)
+            {
+                // Cut of drive letter:  /* C:\ */
+                if (containerPath[1] == ':')
+                {
+                    containerPath = containerPath[3..];
+                }
+
+                containerPath = "Files/" + containerPath;
+            }
+
+            return containerPath;
+        }
+
+        // Ensures that all directory entries for the given segments are created within the tar.
         var directoryEntries = new HashSet<string>();
+        void EnsureDirectoryEntries(TarWriter tar,
+            IReadOnlyList<string> filePathSegments)
+        {
+            var pathBuilder = new StringBuilder();
+            for (int i = 0; i < filePathSegments.Count - 1; i++)
+            {
+                pathBuilder.Append($"{filePathSegments[i]}/");
+
+                string fullPath = pathBuilder.ToString();
+                if (!directoryEntries.Contains(fullPath))
+                {
+                    tar.WriteEntry(CreateTarEntry(TarEntryType.Directory, fullPath));
+                    directoryEntries.Add(fullPath);
+                }
+            }
+        }
+
 
         string tempTarballPath = ContentStore.GetTempFile();
         using (FileStream fs = File.Create(tempTarballPath))
@@ -56,12 +133,24 @@ internal record struct Layer
                     {
                         // Docker treats a COPY instruction that copies to a path like `/app` by
                         // including `app/` as a directory, with no leading slash. Emulate that here.
-                        string containerPath = item.containerPath.TrimStart(PathSeparators);
+                        string containerPath = SanitizeContainerPath(item.containerPath);
 
-                        EnsureDirectoryEntries(writer, directoryEntries, containerPath.Split(PathSeparators));
+                        EnsureDirectoryEntries(writer, containerPath.Split(PathSeparators));
 
-                        writer.WriteEntry(item.path, containerPath);
+                        using var fileStream = File.OpenRead(item.path);
+                        var entry = CreateTarEntry(TarEntryType.RegularFile, containerPath);
+                        entry.DataStream = fileStream;
+
+                        writer.WriteEntry(entry);
                     }
+
+                    // Windows layers need a Hives folder, we do not need to create any Registry Hive deltas inside
+                    if (isWindowsLayer)
+                    {
+                        var entry = CreateTarEntry(TarEntryType.Directory, "Hives/");
+                        writer.WriteEntry(entry);
+                    }
+
                 } // Dispose of the TarWriter before getting the hash so the final data get written to the tar stream
 
                 int bytesWritten = gz.GetCurrentUncompressedHash(uncompressedHash);
@@ -102,28 +191,6 @@ internal record struct Layer
     }
 
     private readonly static char[] PathSeparators = new char[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar };
-
-    /// <summary>
-    /// Ensures that all directory entries for the given segments are created within the tar.
-    /// </summary>
-    /// <param name="tar">The tar into which to add the directory entries.</param>
-    /// <param name="directoryEntries">The lookup of all known directory entries. </param>
-    /// <param name="filePathSegments">The segments of the file within the tar for which to create the folders</param>
-    private static void EnsureDirectoryEntries(TarWriter tar, HashSet<string> directoryEntries, IReadOnlyList<string> filePathSegments)
-    {
-        var pathBuilder = new StringBuilder();
-        for (var i = 0; i < filePathSegments.Count - 1; i++)
-        {
-            pathBuilder.Append($"{filePathSegments[i]}/");
-
-            var fullPath = pathBuilder.ToString(); 
-            if (!directoryEntries.Contains(fullPath))
-            {
-                tar.WriteEntry(new PaxTarEntry(TarEntryType.Directory, fullPath));
-                directoryEntries.Add(fullPath);
-            }
-        }
-    }
 
     /// <summary>
     /// A stream capable of computing the hash digest of raw uncompressed data while also compressing it.

--- a/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
+++ b/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
@@ -66,7 +66,7 @@ public sealed partial class CreateNewImage : Microsoft.Build.Utilities.Task, ICa
 
         SafeLog("Building image '{0}' with tags {1} on top of base image {2}", ImageName, String.Join(",", ImageTags), sourceImageReference);
 
-        Layer newLayer = Layer.FromDirectory(PublishDirectory, WorkingDirectory);
+        Layer newLayer = Layer.FromDirectory(PublishDirectory, WorkingDirectory, imageBuilder.IsWindows);
         imageBuilder.AddLayer(newLayer);
         imageBuilder.SetWorkingDirectory(WorkingDirectory);
         imageBuilder.SetEntryPoint(Entrypoint.Select(i => i.ItemSpec).ToArray(), EntrypointArgs.Select(i => i.ItemSpec).ToArray());

--- a/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -70,19 +70,22 @@
       <ContainerImageTag Condition="'$(ContainerImageTag)' == '' and '$(ContainerImageTags)' == ''">$(Version)</ContainerImageTag>
       <ContainerImageTag Condition="'$(AutoGenerateImageTag)' == 'true' and '$(ContainerImageTags)' == ''">$([System.DateTime]::UtcNow.ToString('yyyyMMddhhmmss'))</ContainerImageTag>
 
-      <ContainerWorkingDirectory Condition="'$(ContainerWorkingDirectory)' == ''">/app</ContainerWorkingDirectory>
-
       <!-- The Container RID should default to the RID used for the entire build (to ensure things run on the platform they are built for), but the user knows best and so should be able to set it explicitly.
                  For builds that have a RID, we default to that RID. Otherwise, we default to the RID of the currently-executing SDK. -->
       <ContainerRuntimeIdentifier Condition="'$(ContainerRuntimeIdentifier)' == '' and '$(IsRidAgnostic)' != 'true'">$(RuntimeIdentifier)</ContainerRuntimeIdentifier>
       <ContainerRuntimeIdentifier Condition="'$(ContainerRuntimeIdentifier)' == '' ">$(NETCoreSdkPortableRuntimeIdentifier)</ContainerRuntimeIdentifier>
+
+      <!-- Set the WorkingDirectory depending on the RID -->
+      <ContainerWorkingDirectory Condition="'$(ContainerWorkingDirectory)' == '' and !$(ContainerRuntimeIdentifier.StartsWith('win')) ">/app</ContainerWorkingDirectory>
+      <ContainerWorkingDirectory Condition="'$(ContainerWorkingDirectory)' == '' and $(ContainerRuntimeIdentifier.StartsWith('win')) ">C:\app</ContainerWorkingDirectory>
     </PropertyGroup>
 
     <ItemGroup Label="Entrypoint Assignment">
-      <!-- For non-apphosts, we need to invoke `dotnet` `workingdir/app` as separate args -->
-      <ContainerEntrypoint Condition="'$(ContainerEntrypoint)' == '' and '$(UseAppHost)' != 'true'" Include="dotnet;$(ContainerWorkingDirectory)/$(TargetFileName)" />
-      <!-- For apphosts, we need to invoke `workingdir/app` as a single arg -->
-      <ContainerEntrypoint Condition="'$(ContainerEntrypoint)' == '' and '$(UseAppHost)' == 'true'" Include="$(ContainerWorkingDirectory)/$(AssemblyName)$(_NativeExecutableExtension)" />
+      <!-- For non-apphosts, we need to invoke `dotnet` `app` as separate args -->
+      <ContainerEntrypoint Condition="'$(ContainerEntrypoint)' == '' and '$(UseAppHost)' != 'true'" Include="dotnet;$(TargetFileName)" />
+      <!-- For apphosts, we need to invoke `app` as a single arg -->
+      <ContainerEntrypoint Condition="'$(ContainerEntrypoint)' == '' and '$(UseAppHost)' == 'true' and !$(ContainerRuntimeIdentifier.StartsWith('win'))" Include="$(ContainerWorkingDirectory)/$(AssemblyName)$(_NativeExecutableExtension)" />
+      <ContainerEntrypoint Condition="'$(ContainerEntrypoint)' == '' and '$(UseAppHost)' == 'true' and $(ContainerRuntimeIdentifier.StartsWith('win'))" Include="$(AssemblyName)$(_NativeExecutableExtension)" />
     </ItemGroup>
 
     <ParseContainerProperties FullyQualifiedBaseImageName="$(ContainerBaseImage)"
@@ -186,7 +189,7 @@
                     ContainerEnvironmentVariables="@(ContainerEnvironmentVariables)"
                     ContainerRuntimeIdentifier="$(ContainerRuntimeIdentifier)"
                     RuntimeIdentifierGraphPath="$(RuntimeIdentifierGraphPath)"> <!-- The RID graph path is provided as a property by the SDK. -->
-      
+
       <Output TaskParameter="GeneratedContainerManifest" PropertyName="GeneratedContainerManifest" />
       <Output TaskParameter="GeneratedContainerConfiguration" PropertyName="GeneratedContainerConfiguration" />
     </CreateNewImage>


### PR DESCRIPTION
Related Issue: https://github.com/dotnet/sdk-container-builds/issues/117

Key change in this PR are: 

1. Handle Windows RIDs in EntryPoint and WorkingDir of images
2. Change the Layer Tar structure to the one needed for Windows layers with `Files/` and `Hives/` and not having a drive letter folder. 
3. Ensure we have the a Security Identifiers set as PAX header for the tar entries allowing `BUILTIN\Users` access to the app folder. 
4. Adopted [this remark](https://github.com/dotnet/sdk-container-builds/pull/323#discussion_r1098544735) from my previous rework to pull the `EnsureDirectoryEntries` into a local function.  
5. I added a test which checks for the expected folder structure of Windows layer. Further tests might be added once there is a Windows Container Runtime available in the CI pipelines. Unfortunately due to https://github.com/dotnet/runtime/issues/81699 I had to also disable the verification of the Security Identifiers. 


