### PR TITLE
validation and tests in `CreateNewImageToolTask`

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,6 +4,8 @@
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <AnalysisLevel>latest-Recommended</AnalysisLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <LangVersion>preview</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning" PrivateAssets="all" IncludeAssets="build; buildMultitargeting" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,6 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
+    <PackageVersion Include="FakeItEasy" Version="7.3.1" />
     <PackageVersion Include="FluentAssertions" Version="6.10.0" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.0.1" />
     <PackageVersion Include="Microsoft.Build.Framework" Version="17.4.0" />

--- a/Microsoft.NET.Build.Containers.IntegrationTests/CommandUtils/CommandResultAssertions.cs
+++ b/Microsoft.NET.Build.Containers.IntegrationTests/CommandUtils/CommandResultAssertions.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Linq;
 using System.Text.RegularExpressions;
 using FluentAssertions;
 using FluentAssertions.Execution;
@@ -103,6 +104,7 @@ namespace Microsoft.DotNet.CommandUtils
             return new AndConstraint<CommandResultAssertions>(this);
         }
 
+#if NET
         internal AndConstraint<CommandResultAssertions> HaveStdOutContainingIgnoreCase(string pattern)
         {
             if (_commandResult.StdOut is null)
@@ -113,6 +115,7 @@ namespace Microsoft.DotNet.CommandUtils
                 .FailWith(AppendDiagnosticsTo($"The command output did not contain expected result (ignoring case): {pattern}{Environment.NewLine}"));
             return new AndConstraint<CommandResultAssertions>(this);
         }
+#endif
 
         internal AndConstraint<CommandResultAssertions> HaveStdOutMatching(string pattern, RegexOptions options = RegexOptions.None)
         {

--- a/Microsoft.NET.Build.Containers.IntegrationTests/CommandUtils/DotnetCommand.cs
+++ b/Microsoft.NET.Build.Containers.IntegrationTests/CommandUtils/DotnetCommand.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.CommandUtils
         {
             if (!string.IsNullOrEmpty(executableFilePath))
             {
-                _executableFilePath = executableFilePath;
+                _executableFilePath = executableFilePath!;
             }
             return this;
         }

--- a/Microsoft.NET.Build.Containers.IntegrationTests/CommandUtils/SdkCommandSpec.cs
+++ b/Microsoft.NET.Build.Containers.IntegrationTests/CommandUtils/SdkCommandSpec.cs
@@ -17,22 +17,22 @@ namespace Microsoft.DotNet.CommandUtils
 
         public string? WorkingDirectory { get; set; }
 
-        public Command ToCommand()
+        public Command ToCommand(bool doNotEscapeArguments = false)
         {
             var process = new Process()
             {
-                StartInfo = ToProcessStartInfo()
+                StartInfo = ToProcessStartInfo(doNotEscapeArguments)
             };
             var ret = new Command(process, trimtrailingNewlines: true);
             return ret;
         }
 
-        public ProcessStartInfo ToProcessStartInfo()
+        public ProcessStartInfo ToProcessStartInfo(bool doNotEscapeArguments = false)
         {
             var ret = new ProcessStartInfo
             {
                 FileName = FileName,
-                Arguments = EscapeArgs(),
+                Arguments = doNotEscapeArguments ? string.Join(" ", Arguments) : EscapeArgs(),
                 UseShellExecute = false
             };
             foreach (var kvp in Environment)

--- a/Microsoft.NET.Build.Containers.IntegrationTests/CommandUtils/StreamForwarder.cs
+++ b/Microsoft.NET.Build.Containers.IntegrationTests/CommandUtils/StreamForwarder.cs
@@ -40,7 +40,14 @@ namespace Microsoft.DotNet.CommandUtils
 
         public StreamForwarder ForwardTo(Action<string> writeLine)
         {
-            ThrowIfNull(writeLine);
+#if NET
+            ArgumentNullException.ThrowIfNull(writeLine);
+#else
+            if (writeLine is null)
+            {
+                throw new ArgumentNullException(nameof(writeLine));
+            }
+#endif
 
             ThrowIfForwarderSet();
 
@@ -97,11 +104,6 @@ namespace Microsoft.DotNet.CommandUtils
             {
                 _writeLine(str);
             }
-        }
-
-        private static void ThrowIfNull(object obj)
-        {
-            ArgumentNullException.ThrowIfNull(obj);
         }
 
         private void ThrowIfForwarderSet()

--- a/Microsoft.NET.Build.Containers.IntegrationTests/CommandUtils/TestCommand.cs
+++ b/Microsoft.NET.Build.Containers.IntegrationTests/CommandUtils/TestCommand.cs
@@ -9,6 +9,7 @@ namespace Microsoft.DotNet.CommandUtils
     internal abstract class TestCommand
     {
         private readonly ITestOutputHelper? _log;
+        private bool _doNotEscapeArguments;
 
         protected TestCommand(ITestOutputHelper? log)
         {
@@ -52,19 +53,10 @@ namespace Microsoft.DotNet.CommandUtils
             return this;
         }
 
-        internal TestCommand WithNoUpdateCheck()
+        internal TestCommand WithRawArguments()
         {
-            Arguments.Add("--no-update-check");
+            _doNotEscapeArguments = true;
             return this;
-        }
-
-        internal ProcessStartInfo GetProcessStartInfo(params string[] args)
-        {
-            SdkCommandSpec commandSpec = CreateCommandSpec(args);
-
-            var psi = commandSpec.ToProcessStartInfo();
-
-            return psi;
         }
 
         internal CommandResult Execute(params string[] args)
@@ -76,7 +68,7 @@ namespace Microsoft.DotNet.CommandUtils
         internal virtual CommandResult Execute(IEnumerable<string> args)
         {
             Command command = CreateCommandSpec(args)
-                .ToCommand()
+                .ToCommand(_doNotEscapeArguments)
                 .CaptureStdOut()
                 .CaptureStdErr();
 

--- a/Microsoft.NET.Build.Containers.IntegrationTests/FullFramework/CreateNewImageToolTaskTests.cs
+++ b/Microsoft.NET.Build.Containers.IntegrationTests/FullFramework/CreateNewImageToolTaskTests.cs
@@ -1,0 +1,207 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Reflection;
+using Microsoft.Build.Utilities;
+using Microsoft.DotNet.CommandUtils;
+using Microsoft.NET.Build.Containers.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.NET.Build.Containers.IntegrationTests.FullFramework;
+
+public class CreateNewImageToolTaskTests
+{
+    private ITestOutputHelper _testOutput;
+
+    public CreateNewImageToolTaskTests(ITestOutputHelper testOutput)
+    {
+        _testOutput = testOutput;
+    }
+
+    [Fact]
+    public void GenerateCommandLineCommands_ThrowsWhenRequiredPropertiesNotSet()
+    {
+        CreateNewImage task = new();
+
+        Exception e = Assert.Throws<InvalidOperationException>(() => task.GenerateCommandLineCommandsInt());
+        Assert.Equal("Required task property 'PublishDirectory' was not set or empty.", e.Message);
+
+        DirectoryInfo publishDir = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), DateTime.Now.ToString("yyyyMMddHHmmssfff")));
+
+        task.PublishDirectory = publishDir.FullName;
+
+        e = Assert.Throws<InvalidOperationException>(() => task.GenerateCommandLineCommandsInt());
+        Assert.Equal("Required task property 'BaseRegistry' was not set or empty.", e.Message);
+
+        task.BaseRegistry = "MyBaseRegistry";
+
+        e = Assert.Throws<InvalidOperationException>(() => task.GenerateCommandLineCommandsInt());
+        Assert.Equal("Required task property 'BaseImageName' was not set or empty.", e.Message);
+
+        task.BaseImageName = "MyBaseImageName";
+
+        e = Assert.Throws<InvalidOperationException>(() => task.GenerateCommandLineCommandsInt());
+        Assert.Equal("Required task property 'ImageName' was not set or empty.", e.Message);
+
+        task.ImageName = "MyImageName";
+
+        e = Assert.Throws<InvalidOperationException>(() => task.GenerateCommandLineCommandsInt());
+        Assert.Equal("Required task property 'WorkingDirectory' was not set or empty.", e.Message);
+
+        task.WorkingDirectory = "MyWorkingDirectory";
+
+        e = Assert.Throws<InvalidOperationException>(() => task.GenerateCommandLineCommandsInt());
+        Assert.Equal("Required task property 'Entrypoint' was not set or empty.", e.Message);
+
+        task.Entrypoint = new[] { new TaskItem("") }; 
+
+        e = Assert.Throws<InvalidOperationException>(() => task.GenerateCommandLineCommandsInt());
+        Assert.Equal("Required task property 'Entrypoint' contains empty items.", e.Message);
+
+        task.Entrypoint = new[] { new TaskItem("MyEntryPoint") };
+
+        string args = task.GenerateCommandLineCommandsInt();
+        string workDir = GetPathToContainerize();
+
+        new BasicCommand(_testOutput, "dotnet", args)
+            .WithRawArguments()
+            .WithWorkingDirectory(workDir)
+            .Execute().Should().Fail()
+            .And.NotHaveStdOutContaining("Description:"); //standard help output for parse error
+
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("ValidTag", true)]
+    public void GenerateCommandLineCommands_BaseImageTag(string value, bool optionExpected = false)
+    {
+        CreateNewImage task = new();
+        DirectoryInfo publishDir = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), DateTime.Now.ToString("yyyyMMddHHmmssfff")));
+        task.PublishDirectory = publishDir.FullName;
+        task.BaseRegistry = "MyBaseRegistry";
+        task.BaseImageName = "MyBaseImageName";
+        task.ImageName = "MyImageName";
+        task.WorkingDirectory = "MyWorkingDirectory";
+        task.Entrypoint = new[] { new TaskItem("MyEntryPoint") };
+
+        task.BaseImageTag = value;
+
+        string args = task.GenerateCommandLineCommandsInt();
+
+        if (optionExpected)
+        {
+            Assert.Contains($"--baseimagetag {value}", args);
+        }
+        else
+        {
+            Assert.DoesNotContain("--baseimagetag", args);
+        }      
+    }
+
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("Valid", true)]
+    public void GenerateCommandLineCommands_OutputRegistry(string value, bool optionExpected = false)
+    {
+        CreateNewImage task = new();
+        DirectoryInfo publishDir = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), DateTime.Now.ToString("yyyyMMddHHmmssfff")));
+        task.PublishDirectory = publishDir.FullName;
+        task.BaseRegistry = "MyBaseRegistry";
+        task.BaseImageName = "MyBaseImageName";
+        task.ImageName = "MyImageName";
+        task.WorkingDirectory = "MyWorkingDirectory";
+        task.Entrypoint = new[] { new TaskItem("MyEntryPoint") };
+
+        task.OutputRegistry = value;
+
+        string args = task.GenerateCommandLineCommandsInt();
+
+        if (optionExpected)
+        {
+            Assert.Contains($"--outputregistry {value}", args);
+        }
+        else
+        {
+            Assert.DoesNotContain("--outputregistry", args);
+        }
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("Valid", true)]
+    public void GenerateCommandLineCommands_ContainerRuntimeIdentifier(string value, bool optionExpected = false)
+    {
+        CreateNewImage task = new();
+        DirectoryInfo publishDir = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), DateTime.Now.ToString("yyyyMMddHHmmssfff")));
+        task.PublishDirectory = publishDir.FullName;
+        task.BaseRegistry = "MyBaseRegistry";
+        task.BaseImageName = "MyBaseImageName";
+        task.ImageName = "MyImageName";
+        task.WorkingDirectory = "MyWorkingDirectory";
+        task.Entrypoint = new[] { new TaskItem("MyEntryPoint") };
+
+        task.ContainerRuntimeIdentifier = value;
+
+        string args = task.GenerateCommandLineCommandsInt();
+        if (optionExpected)
+        {
+            Assert.Contains($"--rid {value}", args);
+        }
+        else
+        {
+            Assert.DoesNotContain("--rid", args);
+        }
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("Valid", true)]
+    public void GenerateCommandLineCommands_RuntimeIdentifierGraphPath(string value, bool optionExpected = false)
+    {
+        CreateNewImage task = new();
+        DirectoryInfo publishDir = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), DateTime.Now.ToString("yyyyMMddHHmmssfff")));
+        task.PublishDirectory = publishDir.FullName;
+        task.BaseRegistry = "MyBaseRegistry";
+        task.BaseImageName = "MyBaseImageName";
+        task.ImageName = "MyImageName";
+        task.WorkingDirectory = "MyWorkingDirectory";
+        task.Entrypoint = new[] { new TaskItem("MyEntryPoint") };
+
+        task.RuntimeIdentifierGraphPath = value;
+
+        string args = task.GenerateCommandLineCommandsInt();
+
+        if (optionExpected)
+        {
+            Assert.Contains($"--ridgraphpath {value}", args);
+        }
+        else
+        {
+            Assert.DoesNotContain("--ridgraphpath", args);
+        }
+    }
+
+    private static string GetPathToContainerize()
+    {
+#if DEBUG
+        string configuration = "Debug";
+#elif RELEASE
+        string configuration = "Release";
+#else
+        throw new NotSupportedException("The configuration is not supported");
+#endif
+
+        return Path.GetFullPath(Path.Combine(new Uri(Assembly.GetExecutingAssembly().CodeBase).LocalPath, $"../../../../../containerize/bin/{configuration}/net7.0"));
+    }
+}

--- a/Microsoft.NET.Build.Containers.IntegrationTests/FullFramework/CreateNewImageToolTaskTests.cs
+++ b/Microsoft.NET.Build.Containers.IntegrationTests/FullFramework/CreateNewImageToolTaskTests.cs
@@ -2,10 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Reflection;
+using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using Microsoft.DotNet.CommandUtils;
 using Microsoft.NET.Build.Containers.Tasks;
-using Newtonsoft.Json.Linq;
+using FakeItEasy;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -26,39 +27,39 @@ public class CreateNewImageToolTaskTests
         CreateNewImage task = new();
 
         Exception e = Assert.Throws<InvalidOperationException>(() => task.GenerateCommandLineCommandsInt());
-        Assert.Equal("Required task property 'PublishDirectory' was not set or empty.", e.Message);
+        Assert.Equal("Required property 'PublishDirectory' was not set or empty.", e.Message);
 
         DirectoryInfo publishDir = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), DateTime.Now.ToString("yyyyMMddHHmmssfff")));
 
         task.PublishDirectory = publishDir.FullName;
 
         e = Assert.Throws<InvalidOperationException>(() => task.GenerateCommandLineCommandsInt());
-        Assert.Equal("Required task property 'BaseRegistry' was not set or empty.", e.Message);
+        Assert.Equal("Required property 'BaseRegistry' was not set or empty.", e.Message);
 
         task.BaseRegistry = "MyBaseRegistry";
 
         e = Assert.Throws<InvalidOperationException>(() => task.GenerateCommandLineCommandsInt());
-        Assert.Equal("Required task property 'BaseImageName' was not set or empty.", e.Message);
+        Assert.Equal("Required property 'BaseImageName' was not set or empty.", e.Message);
 
         task.BaseImageName = "MyBaseImageName";
 
         e = Assert.Throws<InvalidOperationException>(() => task.GenerateCommandLineCommandsInt());
-        Assert.Equal("Required task property 'ImageName' was not set or empty.", e.Message);
+        Assert.Equal("Required property 'ImageName' was not set or empty.", e.Message);
 
         task.ImageName = "MyImageName";
 
         e = Assert.Throws<InvalidOperationException>(() => task.GenerateCommandLineCommandsInt());
-        Assert.Equal("Required task property 'WorkingDirectory' was not set or empty.", e.Message);
+        Assert.Equal("Required property 'WorkingDirectory' was not set or empty.", e.Message);
 
         task.WorkingDirectory = "MyWorkingDirectory";
 
         e = Assert.Throws<InvalidOperationException>(() => task.GenerateCommandLineCommandsInt());
-        Assert.Equal("Required task item 'Entrypoint' was not set or empty.", e.Message);
+        Assert.Equal("Required 'Entrypoint' items were not set.", e.Message);
 
         task.Entrypoint = new[] { new TaskItem("") }; 
 
         e = Assert.Throws<InvalidOperationException>(() => task.GenerateCommandLineCommandsInt());
-        Assert.Equal("Required task item 'Entrypoint' contains empty items.", e.Message);
+        Assert.Equal("Required 'Entrypoint' items contain empty items.", e.Message);
 
         task.Entrypoint = new[] { new TaskItem("MyEntryPoint") };
 
@@ -197,6 +198,13 @@ public class CreateNewImageToolTaskTests
     public void GenerateCommandLineCommands_Labels()
     {
         CreateNewImage task = new();
+
+        List<string?> warnings = new();
+        IBuildEngine buildEngine = A.Fake<IBuildEngine>();
+        A.CallTo(() => buildEngine.LogWarningEvent(A<BuildWarningEventArgs>.Ignored)).Invokes((BuildWarningEventArgs e) => warnings.Add(e.Message));
+
+        task.BuildEngine = buildEngine;
+
         DirectoryInfo publishDir = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), DateTime.Now.ToString("yyyyMMddHHmmssfff")));
         task.PublishDirectory = publishDir.FullName;
         task.BaseRegistry = "MyBaseRegistry";
@@ -219,6 +227,146 @@ public class CreateNewImageToolTaskTests
         Assert.Contains("""
                                       --labels "NoValue=\"\"" "Valid1=\"Val1\"" "Valid12=\"Val2\"" "Valid12=\"\""
                                       """, args);
+        Assert.Equal("Items 'Labels' contain empty item(s) which will be ignored.", Assert.Single(warnings));
+    }
+
+    [Fact]
+    public void GenerateCommandLineCommands_ContainerEnvironmentVariables()
+    {
+        CreateNewImage task = new();
+
+        List<string?> warnings = new();
+        IBuildEngine buildEngine = A.Fake<IBuildEngine>();
+        A.CallTo(() => buildEngine.LogWarningEvent(A<BuildWarningEventArgs>.Ignored)).Invokes((BuildWarningEventArgs e) => warnings.Add(e.Message));
+
+        task.BuildEngine = buildEngine;
+
+        DirectoryInfo publishDir = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), DateTime.Now.ToString("yyyyMMddHHmmssfff")));
+        task.PublishDirectory = publishDir.FullName;
+        task.BaseRegistry = "MyBaseRegistry";
+        task.BaseImageName = "MyBaseImageName";
+        task.ImageName = "MyImageName";
+        task.WorkingDirectory = "MyWorkingDirectory";
+        task.Entrypoint = new[] { new TaskItem("MyEntryPoint") };
+
+        task.ContainerEnvironmentVariables = new[]
+        {
+            new TaskItem("NoValue"),
+            new TaskItem(" "),
+            new TaskItem("Valid1", new Dictionary<string, string>() {{ "Value", "Val1" }}),
+            new TaskItem("Valid12", new Dictionary<string, string>() {{ "Value", "Val2" }}),
+            new TaskItem("Valid12", new Dictionary<string, string>() {{ "Value", "" }})
+        };
+
+        string args = task.GenerateCommandLineCommandsInt();
+
+        Assert.Contains("""
+                                      --environmentvariables "NoValue=\"\"" "Valid1=\"Val1\"" "Valid12=\"Val2\"" "Valid12=\"\""
+                                      """, args);
+        Assert.Equal("Items 'ContainerEnvironmentVariables' contain empty item(s) which will be ignored.", Assert.Single(warnings));
+    }
+
+
+    [Fact]
+    public void GenerateCommandLineCommands_EntryPointArgs()
+    {
+        CreateNewImage task = new();
+
+        List<string?> warnings = new();
+        IBuildEngine buildEngine = A.Fake<IBuildEngine>();
+        A.CallTo(() => buildEngine.LogWarningEvent(A<BuildWarningEventArgs>.Ignored)).Invokes((BuildWarningEventArgs e) => warnings.Add(e.Message));
+
+        task.BuildEngine = buildEngine;
+
+        DirectoryInfo publishDir = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), DateTime.Now.ToString("yyyyMMddHHmmssfff")));
+        task.PublishDirectory = publishDir.FullName;
+        task.BaseRegistry = "MyBaseRegistry";
+        task.BaseImageName = "MyBaseImageName";
+        task.ImageName = "MyImageName";
+        task.WorkingDirectory = "MyWorkingDirectory";
+        task.Entrypoint = new[] { new TaskItem("MyEntryPoint") };
+
+        task.EntrypointArgs = new[]
+        {
+            new TaskItem(""),
+            new TaskItem(" "),
+            new TaskItem("Valid1"),
+            new TaskItem("Valid2"),
+            new TaskItem("Quoted item")
+        };
+
+        string args = task.GenerateCommandLineCommandsInt();
+
+        Assert.Contains("""
+                                      --entrypointargs Valid1 Valid2 "Quoted item"
+                                      """, args);
+        Assert.Equal("Items 'EntrypointArgs' contain empty item(s) which will be ignored.", Assert.Single(warnings));
+    }
+
+    [Fact]
+    public void GenerateCommandLineCommands_ImageTags()
+    {
+        CreateNewImage task = new();
+
+        List<string?> warnings = new();
+        IBuildEngine buildEngine = A.Fake<IBuildEngine>();
+        A.CallTo(() => buildEngine.LogWarningEvent(A<BuildWarningEventArgs>.Ignored)).Invokes((BuildWarningEventArgs e) => warnings.Add(e.Message));
+
+        task.BuildEngine = buildEngine;
+
+        DirectoryInfo publishDir = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), DateTime.Now.ToString("yyyyMMddHHmmssfff")));
+        task.PublishDirectory = publishDir.FullName;
+        task.BaseRegistry = "MyBaseRegistry";
+        task.BaseImageName = "MyBaseImageName";
+        task.ImageName = "MyImageName";
+        task.WorkingDirectory = "MyWorkingDirectory";
+        task.Entrypoint = new[] { new TaskItem("MyEntryPoint") };
+
+        task.ImageTags = new[] { "", " ", "Valid1", "To be quoted" };
+
+        string args = task.GenerateCommandLineCommandsInt();
+
+        Assert.Contains("""
+                                      --imagetags Valid1 "To be quoted"
+                                      """, actualString: args);
+        Assert.Equal("Property 'ImageTags' is empty or contains whitespace and will be ignored.", Assert.Single(warnings));
+    }
+
+    [Fact]
+    public void GenerateCommandLineCommands_ExposedPorts()
+    {
+        CreateNewImage task = new();
+
+        List<string?> warnings = new();
+        IBuildEngine buildEngine = A.Fake<IBuildEngine>();
+        A.CallTo(() => buildEngine.LogWarningEvent(A<BuildWarningEventArgs>.Ignored)).Invokes((BuildWarningEventArgs e) => warnings.Add(e.Message));
+
+        task.BuildEngine = buildEngine;
+
+        DirectoryInfo publishDir = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), DateTime.Now.ToString("yyyyMMddHHmmssfff")));
+        task.PublishDirectory = publishDir.FullName;
+        task.BaseRegistry = "MyBaseRegistry";
+        task.BaseImageName = "MyBaseImageName";
+        task.ImageName = "MyImageName";
+        task.WorkingDirectory = "MyWorkingDirectory";
+        task.Entrypoint = new[] { new TaskItem("MyEntryPoint") };
+
+        task.ExposedPorts = new[]
+        {
+            new TaskItem("1500"),
+            new TaskItem(" "),
+            new TaskItem("1501", new Dictionary<string, string>() {{ "Type", "udp" }}),
+            new TaskItem("1502", new Dictionary<string, string>() {{ "Type", "tcp" }}),
+            new TaskItem("1503", new Dictionary<string, string>() {{ "Type", "" }}),
+            new TaskItem("1504", new Dictionary<string, string>() {{ "Type", "smth-else" }}),
+        };
+
+        string args = task.GenerateCommandLineCommandsInt();
+
+        Assert.Contains("""
+                                      --ports 1500 1501/udp 1502/tcp 1503 1504/smth-else
+                                      """, args);
+        Assert.Equal("Items 'ExposedPorts' contain empty item(s) which will be ignored.", Assert.Single(warnings));
     }
 
     private static string GetPathToContainerize()

--- a/Microsoft.NET.Build.Containers.IntegrationTests/Microsoft.NET.Build.Containers.IntegrationTests.csproj
+++ b/Microsoft.NET.Build.Containers.IntegrationTests/Microsoft.NET.Build.Containers.IntegrationTests.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" />
-   
+    <PackageReference Include="FakeItEasy" />
+    <PackageReference Include="FluentAssertions" /> 
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="all" />
     <PackageReference Include="xunit" />

--- a/Microsoft.NET.Build.Containers.IntegrationTests/Microsoft.NET.Build.Containers.IntegrationTests.csproj
+++ b/Microsoft.NET.Build.Containers.IntegrationTests/Microsoft.NET.Build.Containers.IntegrationTests.csproj
@@ -4,14 +4,12 @@
     <TargetFrameworks>net7.0;net472</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
-    <Nullable>enable</Nullable>
     <DisableMSBuildAssemblyCopyCheck>true</DisableMSBuildAssemblyCopyCheck>
-    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="FakeItEasy" />
-    <PackageReference Include="FluentAssertions" /> 
+    <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="all" />
     <PackageReference Include="xunit" />
@@ -31,7 +29,7 @@
     <ProjectReference Include="..\Microsoft.NET.Build.Containers\Microsoft.NET.Build.Containers.csproj" />
     <ProjectReference Include="..\Microsoft.NET.Build.Containers.UnitTests\Microsoft.NET.Build.Containers.UnitTests.csproj" />
   </ItemGroup>
-  
+
   <!-- net472 builds manually import files to compile -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <Compile Remove="**/*.*" />

--- a/Microsoft.NET.Build.Containers.IntegrationTests/Microsoft.NET.Build.Containers.IntegrationTests.csproj
+++ b/Microsoft.NET.Build.Containers.IntegrationTests/Microsoft.NET.Build.Containers.IntegrationTests.csproj
@@ -1,11 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFrameworks>net7.0;net472</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
     <DisableMSBuildAssemblyCopyCheck>true</DisableMSBuildAssemblyCopyCheck>
+    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -23,11 +24,23 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Utilities.Core" />
     <PackageReference Include="Microsoft.Build" />
-    <PackageReference Include="Microsoft.Build.Framework"/>
+    <PackageReference Include="Microsoft.Build.Framework" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.NET.Build.Containers\Microsoft.NET.Build.Containers.csproj" />
   </ItemGroup>
+  
+  <!-- net472 builds manually import files to compile -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+    <Compile Remove="**/*.*" />
+    <Compile Include="CommandUtils/*.*" />
+    <Compile Include="FullFramework/*.*" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' != 'net472'">
+    <Compile Remove="FullFramework/*.*" />
+  </ItemGroup>
+
 
 </Project>

--- a/Microsoft.NET.Build.Containers.UnitTests/Microsoft.NET.Build.Containers.UnitTests.csproj
+++ b/Microsoft.NET.Build.Containers.UnitTests/Microsoft.NET.Build.Containers.UnitTests.csproj
@@ -1,8 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFrameworks>net7.0;net472</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>
@@ -20,6 +21,14 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.NET.Build.Containers\Microsoft.NET.Build.Containers.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+    <Compile Remove="DockerDaemonAvailableUtils.cs" />
+    <Compile Remove="DockerDaemonTests.cs" />
+    <Compile Remove="RegistryTests.cs" />
+    <Compile Remove="DescriptorTests.cs" />
+    <Compile Remove="ImageBuilderTests.cs" />
   </ItemGroup>
 
 </Project>

--- a/Microsoft.NET.Build.Containers/ContainerBuilder.cs
+++ b/Microsoft.NET.Build.Containers/ContainerBuilder.cs
@@ -62,14 +62,14 @@ public static class ContainerBuilder
             string[] labelPieces = label.Split('=');
 
             // labels are validated by System.CommandLine API
-            imageBuilder.AddLabel(labelPieces[0], labelPieces[1]);
+            imageBuilder.AddLabel(labelPieces[0], TryUnquote(labelPieces[1]));
         }
 
         foreach (string envVar in envVars)
         {
             string[] envPieces = envVar.Split('=', 2);
 
-            imageBuilder.AddEnvironmentVariable(envPieces[0], envPieces[1]);
+            imageBuilder.AddEnvironmentVariable(envPieces[0], TryUnquote(envPieces[1]));
         }
 
         foreach ((int number, PortType type) in exposedPorts)
@@ -134,5 +134,20 @@ public static class ContainerBuilder
             _ => throw new ArgumentException($"Unknown local container daemon type '{localDaemonType}'. Valid local container daemon types are {String.Join(",", KnownDaemonTypes.SupportedLocalDaemonTypes)}", nameof(localDaemonType))
         };
         return daemon;
+    }
+
+    private static string TryUnquote(string path)
+    {
+        if (string.IsNullOrEmpty(path) || path.Length < 2)
+        {
+            return path;
+        }
+        if ((path[0] == '\"' && path[path.Length - 1] == '\"'))
+        {
+            return path.Substring(1, path.Length - 2);
+        }
+
+        //not quoted
+        return path;
     }
 }

--- a/Microsoft.NET.Build.Containers/Microsoft.NET.Build.Containers.csproj
+++ b/Microsoft.NET.Build.Containers/Microsoft.NET.Build.Containers.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>net7.0;net472</TargetFrameworks>
     <ImplicitUsings Condition="'$(TargetFramework)' != 'net472'">enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-    <LangVersion>preview</LangVersion>
 
     <TargetsForTfmSpecificBuildOutput>
       $(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage
@@ -26,7 +24,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Nuget.Packaging" /> 
+    <PackageReference Include="Nuget.Packaging" />
     <PackageReference Include="Valleysoft.DockerCredsProvider" />
   </ItemGroup>
 

--- a/Microsoft.NET.Build.Containers/Microsoft.NET.Build.Containers.csproj
+++ b/Microsoft.NET.Build.Containers/Microsoft.NET.Build.Containers.csproj
@@ -44,6 +44,7 @@
     <Compile Include="Port.cs" />
     <Compile Include="Resources\Resource.cs" />
     <Compile Include="Resources\Strings.Designer.cs" />
+    <Compile Include="Globals.cs" />
   </ItemGroup>
 
   <!-- core remove files specific to net472 workarounds -->

--- a/Microsoft.NET.Build.Containers/Tasks/CreateNewImageToolTask.cs
+++ b/Microsoft.NET.Build.Containers/Tasks/CreateNewImageToolTask.cs
@@ -75,31 +75,31 @@ public partial class CreateNewImage : ToolTask, ICancelableTask
     {
         if (string.IsNullOrWhiteSpace(PublishDirectory))
         {
-            throw new InvalidOperationException($"Required task property '{nameof(PublishDirectory)}' was not set or empty.");
+            throw new InvalidOperationException($"Required property '{nameof(PublishDirectory)}' was not set or empty.");
         }
         if (string.IsNullOrWhiteSpace(BaseRegistry))
         {
-            throw new InvalidOperationException($"Required task property '{nameof(BaseRegistry)}' was not set or empty.");
+            throw new InvalidOperationException($"Required property '{nameof(BaseRegistry)}' was not set or empty.");
         }
         if (string.IsNullOrWhiteSpace(BaseImageName))
         {
-            throw new InvalidOperationException($"Required task property '{nameof(BaseImageName)}' was not set or empty.");
+            throw new InvalidOperationException($"Required property '{nameof(BaseImageName)}' was not set or empty.");
         }
         if (string.IsNullOrWhiteSpace(ImageName))
         {
-            throw new InvalidOperationException($"Required task property '{nameof(ImageName)}' was not set or empty.");
+            throw new InvalidOperationException($"Required property '{nameof(ImageName)}' was not set or empty.");
         }
         if (string.IsNullOrWhiteSpace(WorkingDirectory))
         {
-            throw new InvalidOperationException($"Required task property '{nameof(WorkingDirectory)}' was not set or empty.");
+            throw new InvalidOperationException($"Required property '{nameof(WorkingDirectory)}' was not set or empty.");
         }
         if (Entrypoint.Length == 0)
         {
-            throw new InvalidOperationException($"Required task item '{nameof(Entrypoint)}' was not set or empty.");
+            throw new InvalidOperationException($"Required '{nameof(Entrypoint)}' items were not set.");
         }
         if (Entrypoint.Any(e => string.IsNullOrWhiteSpace(e.ItemSpec)))
         {
-            throw new InvalidOperationException($"Required task item '{nameof(Entrypoint)}' contains empty items.");
+            throw new InvalidOperationException($"Required '{nameof(Entrypoint)}' items contain empty items.");
         }
 
         CommandLineBuilder builder = new();
@@ -130,19 +130,19 @@ public partial class CreateNewImage : ToolTask, ICancelableTask
 
         if (EntrypointArgs.Any(e => string.IsNullOrWhiteSpace(e.ItemSpec)))
         {
-            //Log.LogWarning($"Item '{nameof(EntrypointArgs)}' contains empty items which will be ignored.");
+            Log.LogWarning($"Items '{nameof(EntrypointArgs)}' contain empty item(s) which will be ignored.");
         }
         ITaskItem[] sanitizedEntryPointArgs = EntrypointArgs.Where(e => !string.IsNullOrWhiteSpace(e.ItemSpec)).ToArray();
         builder.AppendSwitchIfNotNull("--entrypointargs ", sanitizedEntryPointArgs, delimiter: " ");
 
         if (Labels.Any(e => string.IsNullOrWhiteSpace(e.ItemSpec)))
         {
-            //Log.LogWarning($"Item'{nameof(Labels)}' contains empty items which will be ignored.");
+            Log.LogWarning($"Items '{nameof(Labels)}' contain empty item(s) which will be ignored.");
         }
         var sanitizedLabels = Labels.Where(e => !string.IsNullOrWhiteSpace(e.ItemSpec));
         if (sanitizedLabels.Any(i => i.GetMetadata("Value") is null))
         {
-            //Log.LogWarning($"Item '{nameof(Labels)}' contains items without metadata 'Value', and they will be ignored.");
+            Log.LogWarning($"Item '{nameof(Labels)}' contains items without metadata 'Value', and they will be ignored.");
             sanitizedLabels = sanitizedLabels.Where(i => i.GetMetadata("Value") is not null);
         }
 
@@ -151,14 +151,14 @@ public partial class CreateNewImage : ToolTask, ICancelableTask
 
         if (ImageTags.Any(string.IsNullOrWhiteSpace))
         {
-            //Log.LogWarning($"Task property '{nameof(ImageTags)}' contains empty items which will be ignored.");
+            Log.LogWarning($"Property '{nameof(ImageTags)}' is empty or contains whitespace and will be ignored.");
         }
         string[] sanitizedImageTags = ImageTags.Where(i => !string.IsNullOrWhiteSpace(i)).ToArray();
         builder.AppendSwitchIfNotNull("--imagetags ", sanitizedImageTags, delimiter: " ");
 
         if (ExposedPorts.Any(e => string.IsNullOrWhiteSpace(e.ItemSpec)))
         {
-            //Log.LogWarning($"Item '{nameof(ExposedPorts)}' contains empty items which will be ignored.");
+            Log.LogWarning($"Items '{nameof(ExposedPorts)}' contain empty item(s) which will be ignored.");
         }
         var sanitizedPorts = ExposedPorts.Where(e => !string.IsNullOrWhiteSpace(e.ItemSpec));
         string[] readyPorts =
@@ -170,12 +170,12 @@ public partial class CreateNewImage : ToolTask, ICancelableTask
 
         if (ContainerEnvironmentVariables.Any(e => string.IsNullOrWhiteSpace(e.ItemSpec)))
         {
-            //Log.LogWarning($"Item '{nameof(ContainerEnvironmentVariables)}' contains empty items which will be ignored.");
+            Log.LogWarning($"Items '{nameof(ContainerEnvironmentVariables)}' contain empty item(s) which will be ignored.");
         }
         var sanitizedEnvVariables = ContainerEnvironmentVariables.Where(e => !string.IsNullOrWhiteSpace(e.ItemSpec));
         if (sanitizedEnvVariables.Any(i => i.GetMetadata("Value") is null))
         {
-            //Log.LogWarning($"Item '{nameof(ContainerEnvironmentVariables)}' contains items without metadata 'Value', and they will be ignored.");
+            Log.LogWarning($"Item '{nameof(ContainerEnvironmentVariables)}' contains items without metadata 'Value', and they will be ignored.");
             sanitizedEnvVariables = sanitizedEnvVariables.Where(i => i.GetMetadata("Value") is not null);
         }
         string[] readyEnvVariables = sanitizedEnvVariables.Select(i => i.ItemSpec + "=" + Quote(i.GetMetadata("Value"))).ToArray();

--- a/containerize/containerize.csproj
+++ b/containerize/containerize.csproj
@@ -4,8 +4,6 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Implemented validation and added tests for generating parameters for `containerize`

TODO:

- [x] validation and checks for `Labels`, `ImageTags`, `ExposedPorts`, `ContainerEnvironmentVariables`
- [x] https://github.com/dotnet/sdk-container-builds/issues/172