### PR TITLE
Make base image properties top level

### DIFF
--- a/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -13,6 +13,23 @@
                           )">true</_IsSDKContainerAllowedVersion>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!-- Reference data about this project -->
+    <_AspNetCoreFrameworkReference>@(FrameworkReference->WithMetadataValue('Identity', 'Microsoft.AspNetCore.App')</_AspNetCoreFrameworkReference>
+    <_IsAspNet Condition=" '$(UsingMicrosoftNETSdkWeb)' == 'true' or '$(_AspNetCoreFrameworkReference)' != '' ">true</_IsAspNet>
+    <_IsSelfContained Condition="'$(SelfContained)' == 'true' or '$(PublishSelfContained)' == 'true'">true</_IsSelfContained>
+
+    <!-- Compute private defaults -->
+    <_ContainerBaseRegistry>mcr.microsoft.com</_ContainerBaseRegistry>
+    <_ContainerBaseImageName Condition="'$(_IsSelfContained)' == 'true'">dotnet/runtime-deps</_ContainerBaseImageName>
+    <_ContainerBaseImageName Condition="'$(_ContainerBaseImageName)' == '' and '$(_IsAspNet)' == 'true'">dotnet/aspnet</_ContainerBaseImageName>
+    <_ContainerBaseImageName Condition="'$(_ContainerBaseImageName)' == ''">dotnet/runtime</_ContainerBaseImageName>
+    <_ContainerBaseImageTag>$(_TargetFrameworkVersionWithoutV)</_ContainerBaseImageTag>
+
+    <!-- Compute base image -->
+    <ContainerBaseImage Condition="'$(ContainerBaseImage)' == ''">$(_ContainerBaseRegistry)/$(_ContainerBaseImageName):$(_ContainerBaseImageTag)</ContainerBaseImage>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectCapability Include="NetSdkOCIImageBuild" />
   </ItemGroup>
@@ -28,21 +45,6 @@
   </Target>
 
   <Target Name="ComputeContainerConfig">
-    <!-- Reference data about this project -->
-    <PropertyGroup>
-      <_IsAspNet Condition="@(ProjectCapability->Count()) > 0 and @(ProjectCapability->AnyHaveMetadataValue('Identity', 'AspNetCore'))">true</_IsAspNet>
-      <_IsSelfContained Condition="'$(SelfContained)' == 'true' or '$(PublishSelfContained)' == 'true'">true</_IsSelfContained>
-    </PropertyGroup>
-
-    <!-- Compute private defaults -->
-    <PropertyGroup Condition="$(ContainerBaseImage) == ''">
-      <_ContainerBaseRegistry>mcr.microsoft.com</_ContainerBaseRegistry>
-      <_ContainerBaseImageName Condition="'$(_IsSelfContained)' == 'true'">dotnet/runtime-deps</_ContainerBaseImageName>
-      <_ContainerBaseImageName Condition="'$(_ContainerBaseImageName)' == '' and '$(_IsAspNet)' == 'true'">dotnet/aspnet</_ContainerBaseImageName>
-      <_ContainerBaseImageName Condition="'$(_ContainerBaseImageName)' == ''">dotnet/runtime</_ContainerBaseImageName>
-      <_ContainerBaseImageTag>$(_TargetFrameworkVersionWithoutV)</_ContainerBaseImageTag>
-    </PropertyGroup>
-
     <PropertyGroup Label="VS defaults">
       <!-- RegistryUrl is used by existing VS targets for Docker builds - this lets us fill that void -->
       <ContainerRegistry Condition="'$(RegistryUrl)' != ''">$(RegistryUrl)</ContainerRegistry>
@@ -54,8 +56,6 @@
 
     <!-- Container Defaults -->
     <PropertyGroup>
-      <ContainerBaseImage Condition="'$(ContainerBaseImage)' == ''">$(_ContainerBaseRegistry)/$(_ContainerBaseImageName):$(_ContainerBaseImageTag)</ContainerBaseImage>
-
       <!-- An empty ContainerRegistry implies pushing to the local daemon, putting this here for documentation purposes -->
       <!-- <ContainerRegistry></ContainerRegistry> -->
 

--- a/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -13,23 +13,6 @@
                           )">true</_IsSDKContainerAllowedVersion>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <!-- Reference data about this project -->
-    <_AspNetCoreFrameworkReference>@(FrameworkReference->WithMetadataValue('Identity', 'Microsoft.AspNetCore.App')</_AspNetCoreFrameworkReference>
-    <_IsAspNet Condition=" '$(UsingMicrosoftNETSdkWeb)' == 'true' or '$(_AspNetCoreFrameworkReference)' != '' ">true</_IsAspNet>
-    <_IsSelfContained Condition="'$(SelfContained)' == 'true' or '$(PublishSelfContained)' == 'true'">true</_IsSelfContained>
-
-    <!-- Compute private defaults -->
-    <_ContainerBaseRegistry>mcr.microsoft.com</_ContainerBaseRegistry>
-    <_ContainerBaseImageName Condition="'$(_IsSelfContained)' == 'true'">dotnet/runtime-deps</_ContainerBaseImageName>
-    <_ContainerBaseImageName Condition="'$(_ContainerBaseImageName)' == '' and '$(_IsAspNet)' == 'true'">dotnet/aspnet</_ContainerBaseImageName>
-    <_ContainerBaseImageName Condition="'$(_ContainerBaseImageName)' == ''">dotnet/runtime</_ContainerBaseImageName>
-    <_ContainerBaseImageTag>$(_TargetFrameworkVersionWithoutV)</_ContainerBaseImageTag>
-
-    <!-- Compute base image -->
-    <ContainerBaseImage Condition="'$(ContainerBaseImage)' == ''">$(_ContainerBaseRegistry)/$(_ContainerBaseImageName):$(_ContainerBaseImageTag)</ContainerBaseImage>
-  </PropertyGroup>
-
   <ItemGroup>
     <ProjectCapability Include="NetSdkOCIImageBuild" />
   </ItemGroup>
@@ -44,7 +27,25 @@
     <Error Condition="'$(_IsSDKContainerAllowedVersion)' != 'true'" Code="CONTAINER002" Text="The current .NET SDK ($(NETCoreSdkVersion)) doesn't support containerization. Please use version 7.0.100 or higher to enable containerization." />
   </Target>
 
-  <Target Name="ComputeContainerConfig">
+  <Target Name="ComputeContainerBaseImage" Returns="$(ContainerBaseImage)">
+    <PropertyGroup>
+      <!-- Reference data about this project -->
+      <_IsSelfContained Condition="'$(SelfContained)' == 'true' or '$(PublishSelfContained)' == 'true'">true</_IsSelfContained>
+      <_IsAspNet Condition="@(FrameworkReference->Count()) > 0 and @(FrameworkReference->AnyHaveMetadataValue('Identity', 'Microsoft.AspnetCore.App'))">true</_IsAspNet>
+
+      <!-- Compute private defaults -->
+      <_ContainerBaseRegistry>mcr.microsoft.com</_ContainerBaseRegistry>
+      <_ContainerBaseImageName Condition="'$(_IsSelfContained)' == 'true'">dotnet/runtime-deps</_ContainerBaseImageName>
+      <_ContainerBaseImageName Condition="'$(_ContainerBaseImageName)' == '' and '$(_IsAspNet)' == 'true'">dotnet/aspnet</_ContainerBaseImageName>
+      <_ContainerBaseImageName Condition="'$(_ContainerBaseImageName)' == ''">dotnet/runtime</_ContainerBaseImageName>
+      <_ContainerBaseImageTag>$(_TargetFrameworkVersionWithoutV)</_ContainerBaseImageTag>
+
+      <!-- Compute base runtime image -->
+      <ContainerBaseImage Condition="'$(ContainerBaseImage)' == ''">$(_ContainerBaseRegistry)/$(_ContainerBaseImageName):$(_ContainerBaseImageTag)</ContainerBaseImage>
+    </PropertyGroup>
+  </Target>
+
+  <Target Name="ComputeContainerConfig" DependsOnTargets="ComputeContainerBaseImage">
     <PropertyGroup Label="VS defaults">
       <!-- RegistryUrl is used by existing VS targets for Docker builds - this lets us fill that void -->
       <ContainerRegistry Condition="'$(RegistryUrl)' != ''">$(RegistryUrl)</ContainerRegistry>


### PR DESCRIPTION
This updates the logic used to identify Asp.NET/SelfContainer projects to allow the dependent ContainerBaseImage to be a top level property rather than having to be calculated in the ComputeContainerConfig target. This makes the targets much easier to work with from outside of MSBuild (particularly in VS/VScode extensions) if one wants to determine the base image that the SDK will use.

The `UsingMicrosoftNETSdkWeb` property is set to true by the Asp.NET SDK before the Microsoft.NET.Build.Containers targets would be run (unlike the AspNetCore capability) and the Microsoft.AspNetCore.App framework reference should also be set early enough to be depended on for a top level property.