### PR TITLE
Support History/Build configs in an immutable way

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -161,13 +161,13 @@ dotnet_diagnostic.CA1001.severity = suggestion
 dotnet_diagnostic.CA1305.severity = suggestion
 
 # Identifiers should not contain underscores
-dotnet_diagnostic.CA1707.severity = suggestion
+dotnet_diagnostic.CA1707.severity = silent
 
 # Do not directly await a Task
 dotnet_diagnostic.CA2007.severity = warning
 
 # Do not raise reserved exception types
-dotnet_diagnostic.CA2201.severity = suggestion
+dotnet_diagnostic.CA2201.severity = silent
 
 # Using directive is unnecessary
 dotnet_diagnostic.IDE0005.severity = warning

--- a/.editorconfig
+++ b/.editorconfig
@@ -161,13 +161,13 @@ dotnet_diagnostic.CA1001.severity = suggestion
 dotnet_diagnostic.CA1305.severity = suggestion
 
 # Identifiers should not contain underscores
-dotnet_diagnostic.CA1707.severity = silent
+dotnet_diagnostic.CA1707.severity = suggestion
 
 # Do not directly await a Task
 dotnet_diagnostic.CA2007.severity = warning
 
 # Do not raise reserved exception types
-dotnet_diagnostic.CA2201.severity = silent
+dotnet_diagnostic.CA2201.severity = suggestion
 
 # Using directive is unnecessary
 dotnet_diagnostic.IDE0005.severity = warning

--- a/Microsoft.NET.Build.Containers.IntegrationTests/Microsoft.NET.Build.Containers.IntegrationTests.csproj
+++ b/Microsoft.NET.Build.Containers.IntegrationTests/Microsoft.NET.Build.Containers.IntegrationTests.csproj
@@ -27,6 +27,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.NET.Build.Containers\Microsoft.NET.Build.Containers.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' != 'net472'">
     <ProjectReference Include="..\Microsoft.NET.Build.Containers.UnitTests\Microsoft.NET.Build.Containers.UnitTests.csproj" />
   </ItemGroup>
 

--- a/Microsoft.NET.Build.Containers.UnitTests/ImageBuilderTests.cs
+++ b/Microsoft.NET.Build.Containers.UnitTests/ImageBuilderTests.cs
@@ -2,10 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text.Json.Nodes;
-using Microsoft.NET.Build.Containers;
 using Xunit;
 
-namespace Test.Microsoft.NET.Build.Containers;
+namespace Microsoft.NET.Build.Containers.UnitTests;
 
 public class ImageBuilderTests
 {

--- a/Microsoft.NET.Build.Containers.UnitTests/ImageConfigTests.cs
+++ b/Microsoft.NET.Build.Containers.UnitTests/ImageConfigTests.cs
@@ -2,10 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text.Json.Nodes;
-using Microsoft.NET.Build.Containers;
 using Xunit;
 
-namespace Test.Microsoft.NET.Build.Containers;
+namespace Microsoft.NET.Build.Containers.UnitTests;
 
 public class ImageConfigTests
 {

--- a/Microsoft.NET.Build.Containers.UnitTests/ImageConfigTests.cs
+++ b/Microsoft.NET.Build.Containers.UnitTests/ImageConfigTests.cs
@@ -1,0 +1,59 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json.Nodes;
+using Microsoft.NET.Build.Containers;
+using Xunit;
+
+namespace Test.Microsoft.NET.Build.Containers;
+
+public class ImageConfigTests
+{
+    private const string SampleImageConfig = """
+                {
+                    "architecture": "amd64",
+                    "config": {
+                      "User": "app",
+                      "Env": [
+                        "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+                        "ASPNETCORE_URLS=http://+:80",
+                        "DOTNET_RUNNING_IN_CONTAINER=true",
+                        "DOTNET_VERSION=7.0.2",
+                        "ASPNET_VERSION=7.0.2"
+                      ],
+                      "Cmd": ["bash"],
+                      "Volumes": {
+                        "/var/log/": {}
+                      },
+                      "WorkingDir": "/app",
+                      "Entrypoint": null,
+                      "Labels": null,
+                      "StopSignal": "SIGTERM"
+                    },
+                    "created": "2023-02-04T08:14:52.000901321Z",
+                    "os": "linux",
+                    "rootfs": {
+                      "type": "layers",
+                      "diff_ids": [
+                        "sha256:bd2fe8b74db65d82ea10db97368d35b92998d4ea0e7e7dc819481fe4a68f64cf",
+                        "sha256:94100d1041b650c6f7d7848c550cd98c25d0bdc193d30692e5ea5474d7b3b085",
+                        "sha256:53c2a75a33c8f971b4b5036d34764373e134f91ee01d8053b4c3573c42e1cf5d",
+                        "sha256:49a61320e585180286535a2545be5722b09e40ad44c7c190b20ec96c9e42e4a3",
+                        "sha256:8a379cce2ac272aa71aa029a7bbba85c852ba81711d9f90afaefd3bf5036dc48"
+                      ]
+                    }
+                }
+                """;
+
+    [InlineData("User")]
+    [InlineData("Volumes")]
+    [InlineData("StopSignal")]
+    [Theory]
+    public void PassesThroughPropertyEvenThoughPropertyIsntExplicitlyHandled(string property)
+    {
+        ImageConfig c = new(SampleImageConfig);
+        JsonNode after = JsonNode.Parse(c.BuildConfig())!;
+        JsonNode? prop = after["config"]?[property];
+        Assert.NotNull(prop);
+    }
+}

--- a/Microsoft.NET.Build.Containers.UnitTests/Microsoft.NET.Build.Containers.UnitTests.csproj
+++ b/Microsoft.NET.Build.Containers.UnitTests/Microsoft.NET.Build.Containers.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net472</TargetFrameworks>
+    <TargetFrameworks>net7.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
@@ -20,15 +20,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.NET.Build.Containers\Microsoft.NET.Build.Containers.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
-    <Compile Remove="DockerDaemonAvailableUtils.cs" />
-    <Compile Remove="DockerDaemonTests.cs" />
-    <Compile Remove="RegistryTests.cs" />
-    <Compile Remove="DescriptorTests.cs" />
-    <Compile Remove="ImageBuilderTests.cs" />
-    <Compile Remove="ImageConfigTests.cs" />
   </ItemGroup>
 
 </Project>

--- a/Microsoft.NET.Build.Containers.UnitTests/Microsoft.NET.Build.Containers.UnitTests.csproj
+++ b/Microsoft.NET.Build.Containers.UnitTests/Microsoft.NET.Build.Containers.UnitTests.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Microsoft.NET.Build.Containers\Microsoft.NET.Build.Containers.csproj" />
+    <ProjectReference Include="..\Microsoft.NET.Build.Containers\Microsoft.NET.Build.Containers.csproj" SetTargetFramework="TargetFramework=net7.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">

--- a/Microsoft.NET.Build.Containers.UnitTests/Microsoft.NET.Build.Containers.UnitTests.csproj
+++ b/Microsoft.NET.Build.Containers.UnitTests/Microsoft.NET.Build.Containers.UnitTests.csproj
@@ -5,7 +5,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
-
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -21,6 +20,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.NET.Build.Containers\Microsoft.NET.Build.Containers.csproj" />
+    <Compile Remove="ImageConfigTests.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">

--- a/Microsoft.NET.Build.Containers.UnitTests/Microsoft.NET.Build.Containers.UnitTests.csproj
+++ b/Microsoft.NET.Build.Containers.UnitTests/Microsoft.NET.Build.Containers.UnitTests.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Microsoft.NET.Build.Containers\Microsoft.NET.Build.Containers.csproj" SetTargetFramework="TargetFramework=net7.0" />
+    <ProjectReference Include="..\Microsoft.NET.Build.Containers\Microsoft.NET.Build.Containers.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">

--- a/Microsoft.NET.Build.Containers.UnitTests/Microsoft.NET.Build.Containers.UnitTests.csproj
+++ b/Microsoft.NET.Build.Containers.UnitTests/Microsoft.NET.Build.Containers.UnitTests.csproj
@@ -20,7 +20,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.NET.Build.Containers\Microsoft.NET.Build.Containers.csproj" />
-    <Compile Remove="ImageConfigTests.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">

--- a/Microsoft.NET.Build.Containers.UnitTests/Microsoft.NET.Build.Containers.UnitTests.csproj
+++ b/Microsoft.NET.Build.Containers.UnitTests/Microsoft.NET.Build.Containers.UnitTests.csproj
@@ -28,6 +28,7 @@
     <Compile Remove="RegistryTests.cs" />
     <Compile Remove="DescriptorTests.cs" />
     <Compile Remove="ImageBuilderTests.cs" />
+    <Compile Remove="ImageConfigTests.cs" />
   </ItemGroup>
 
 </Project>

--- a/Microsoft.NET.Build.Containers.UnitTests/Resources/ResourceTests.cs
+++ b/Microsoft.NET.Build.Containers.UnitTests/Resources/ResourceTests.cs
@@ -4,7 +4,7 @@
 using Microsoft.NET.Build.Containers.Resources;
 using Xunit;
 
-namespace Test.Microsoft.NET.Build.Containers.UnitTests.Resources
+namespace Microsoft.NET.Build.Containers.UnitTests.Resources
 {
     public class ResourceTests
     {

--- a/Microsoft.NET.Build.Containers/Constants.cs
+++ b/Microsoft.NET.Build.Containers/Constants.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Reflection;
+
+namespace Microsoft.NET.Build.Containers;
+
+public static class Constants {
+    public static readonly string Version = typeof(Registry).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "";
+
+}

--- a/Microsoft.NET.Build.Containers/ImageConfig.cs
+++ b/Microsoft.NET.Build.Containers/ImageConfig.cs
@@ -24,7 +24,7 @@ internal sealed class ImageConfig
     private readonly List<string> _rootFsLayers;
     private readonly string _architecture;
     private readonly string _os;
-    private List<HistoryEntry> _history;
+    private readonly List<HistoryEntry> _history;
 
     internal ImageConfig(JsonNode config)
     {
@@ -87,7 +87,7 @@ internal sealed class ImageConfig
         }
 
         // add a history entry for ourselves so folks can map generated layers to the Dockerfile commands
-        _history.Add(new HistoryEntry(DateTime.UtcNow, ".NET SDK ", null));
+        _history.Add(new HistoryEntry(DateTime.UtcNow, $".NET SDK Container Tooling, version {Constants.Version}", null));
 
         var configContainer = new JsonObject()
         {

--- a/Microsoft.NET.Build.Containers/ImageConfig.cs
+++ b/Microsoft.NET.Build.Containers/ImageConfig.cs
@@ -87,7 +87,7 @@ internal sealed class ImageConfig
         }
 
         // add a history entry for ourselves so folks can map generated layers to the Dockerfile commands
-        _history.Add(new HistoryEntry(DateTime.UtcNow, $".NET SDK Container Tooling, version {Constants.Version}", null));
+        _history.Add(new HistoryEntry(DateTime.UtcNow, $".NET SDK Container Tooling, version {Constants.Version}", null, null, null));
 
         var configContainer = new JsonObject()
         {
@@ -111,15 +111,29 @@ internal sealed class ImageConfig
 
     private JsonObject CreateHistory(HistoryEntry h)
     {
-        var history = new JsonObject()
+        var history = new JsonObject();
+
+        if (h.author is not null)
         {
-            ["created"] = RFC3339Format(h.created),
-            ["created_by"] = h.created_by,
-        };
+            history["author"] = h.author;
+        }
+        if (h.comment is not null)
+        {
+            history["comment"] = h.comment;
+        }
+        if (h.created is {} date)
+        {
+            history["created"] = RFC3339Format(date);
+        }
+        if (h.created_by is not null)
+        {
+            history["created_by"] = h.created_by;
+        }
         if (h.empty_layer is not null)
         {
             history["empty_layer"] = h.empty_layer;
         }
+
         return history;
     }
 
@@ -264,5 +278,5 @@ internal sealed class ImageConfig
         }
     }
 
-    private record HistoryEntry(DateTimeOffset created, string created_by, bool? empty_layer);
+    private record HistoryEntry(DateTimeOffset? created, string? created_by, bool? empty_layer, string? comment, string? author);
 }

--- a/Microsoft.NET.Build.Containers/ImageConfig.cs
+++ b/Microsoft.NET.Build.Containers/ImageConfig.cs
@@ -26,6 +26,10 @@ internal sealed class ImageConfig
     private readonly string _os;
     private readonly List<HistoryEntry> _history;
 
+    internal ImageConfig(string imageConfigJson) : this(JsonNode.Parse(imageConfigJson)!)
+    {
+    }
+
     internal ImageConfig(JsonNode config)
     {
         _config = config as JsonObject ?? throw new ArgumentException($"{nameof(config)} should be a JSON object.", nameof(config));
@@ -90,12 +94,12 @@ internal sealed class ImageConfig
         // preserve them if they're already set in the base image.
         foreach (string propertyName in new [] { "User", "Volumes", "StopSignal" })
         {
-            if (_config["config"]?[propertyName] is JsonValue propertyValue)
+            if (_config["config"]?[propertyName] is JsonNode propertyValue)
             {
                 // we can't just copy the property value because JsonValues have Parents
                 // and they cannot be re-parented. So we need to Clone them, but there's
                 // not an API for cloning, so the recommendation is to stringify and parse.
-                newConfig[propertyName] = JsonValue.Parse(propertyValue.ToJsonString());
+                newConfig[propertyName] = JsonNode.Parse(propertyValue.ToJsonString());
             }
         }
 

--- a/Microsoft.NET.Build.Containers/ImageConfig.cs
+++ b/Microsoft.NET.Build.Containers/ImageConfig.cs
@@ -86,6 +86,15 @@ internal sealed class ImageConfig
             }
         }
 
+        // not yet directly supported fields
+        foreach (string propertyName in new [] { "User", "Volumes", "StopSignal" })
+        {
+            if (_config["config"]?[propertyName] is JsonValue propertyValue)
+            {
+                newConfig[propertyName] = propertyValue;
+            }
+        }
+
         // add a history entry for ourselves so folks can map generated layers to the Dockerfile commands
         _history.Add(new HistoryEntry(created: DateTime.UtcNow, author: ".NET SDK", created_by: $".NET SDK Container Tooling, version {Constants.Version}"));
 

--- a/Microsoft.NET.Build.Containers/ImageConfig.cs
+++ b/Microsoft.NET.Build.Containers/ImageConfig.cs
@@ -86,7 +86,8 @@ internal sealed class ImageConfig
             }
         }
 
-        // not yet directly supported fields
+        // These fields aren't (yet) supported by the task layer, but we should
+        // preserve them if they're already set in the base image.
         foreach (string propertyName in new [] { "User", "Volumes", "StopSignal" })
         {
             if (_config["config"]?[propertyName] is JsonValue propertyValue)

--- a/Microsoft.NET.Build.Containers/ImageConfig.cs
+++ b/Microsoft.NET.Build.Containers/ImageConfig.cs
@@ -87,7 +87,7 @@ internal sealed class ImageConfig
         }
 
         // add a history entry for ourselves so folks can map generated layers to the Dockerfile commands
-        _history.Add(new HistoryEntry(DateTime.UtcNow, $".NET SDK Container Tooling, version {Constants.Version}", null, null, null));
+        _history.Add(new HistoryEntry(created: DateTime.UtcNow, author: ".NET SDK", created_by: $".NET SDK Container Tooling, version {Constants.Version}"));
 
         var configContainer = new JsonObject()
         {
@@ -278,5 +278,5 @@ internal sealed class ImageConfig
         }
     }
 
-    private record HistoryEntry(DateTimeOffset? created, string? created_by, bool? empty_layer, string? comment, string? author);
+    private record HistoryEntry(DateTimeOffset? created = null, string? created_by = null, bool? empty_layer = null, string? comment = null, string? author = null);
 }

--- a/Microsoft.NET.Build.Containers/ImageConfig.cs
+++ b/Microsoft.NET.Build.Containers/ImageConfig.cs
@@ -92,7 +92,10 @@ internal sealed class ImageConfig
         {
             if (_config["config"]?[propertyName] is JsonValue propertyValue)
             {
-                newConfig[propertyName] = propertyValue;
+                // we can't just copy the property value because JsonValues have Parents
+                // and they cannot be re-parented. So we need to Clone them, but there's
+                // not an API for cloning, so the recommendation is to stringify and parse.
+                newConfig[propertyName] = JsonValue.Parse(propertyValue.ToJsonString());
             }
         }
 

--- a/Microsoft.NET.Build.Containers/Layer.cs
+++ b/Microsoft.NET.Build.Containers/Layer.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Formats.Tar;
+using System.Globalization;
 using System.IO.Compression;
 using System.Security.Cryptography;
 using System.Text;
@@ -114,9 +115,9 @@ internal record struct Layer
         var pathBuilder = new StringBuilder();
         for (var i = 0; i < filePathSegments.Count - 1; i++)
         {
-            pathBuilder.Append($"{filePathSegments[i]}/");
+            pathBuilder.Append(CultureInfo.InvariantCulture, $"{filePathSegments[i]}/");
 
-            var fullPath = pathBuilder.ToString(); 
+            var fullPath = pathBuilder.ToString();
             if (!directoryEntries.Contains(fullPath))
             {
                 tar.WriteEntry(new PaxTarEntry(TarEntryType.Directory, fullPath));

--- a/Microsoft.NET.Build.Containers/PublicAPI/net7.0/PublicAPI.Unshipped.txt
+++ b/Microsoft.NET.Build.Containers/PublicAPI/net7.0/PublicAPI.Unshipped.txt
@@ -1,5 +1,7 @@
 ﻿const Microsoft.NET.Build.Containers.KnownDaemonTypes.Docker = "Docker" -> string!
 Microsoft.NET.Build.Containers.BaseImageNotFoundException
+Microsoft.NET.Build.Containers.Constants
+static readonly Microsoft.NET.Build.Containers.Constants.Version -> string!
 Microsoft.NET.Build.Containers.ContainerBuilder
 Microsoft.NET.Build.Containers.ContainerHelpers
 Microsoft.NET.Build.Containers.ContainerHelpers.ParsePortError
@@ -117,6 +119,7 @@ Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ContainerizeDirectory.set ->
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ContainerRuntimeIdentifier.get -> string!
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ContainerRuntimeIdentifier.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.CreateNewImage() -> void
+Microsoft.NET.Build.Containers.Tasks.CreateNewImage.Dispose() -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.Entrypoint.get -> Microsoft.Build.Framework.ITaskItem![]!
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.Entrypoint.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.EntrypointArgs.get -> Microsoft.Build.Framework.ITaskItem![]!

--- a/Microsoft.NET.Build.Containers/Resources/Resource.cs
+++ b/Microsoft.NET.Build.Containers/Resources/Resource.cs
@@ -46,7 +46,7 @@ namespace Microsoft.NET.Build.Containers.Resources
 
             return resource is null ?
                 $"<{name}>" :
-                string.Format(resource, args);
+                string.Format(CultureInfo.CurrentCulture, resource, args);
         }
     }
 }

--- a/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
+++ b/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
@@ -7,7 +7,7 @@ using Microsoft.NET.Build.Containers.Resources;
 
 namespace Microsoft.NET.Build.Containers.Tasks;
 
-public sealed partial class CreateNewImage : Microsoft.Build.Utilities.Task, ICancelableTask
+public sealed partial class CreateNewImage : Microsoft.Build.Utilities.Task, ICancelableTask, IDisposable
 {
     private readonly CancellationTokenSource _cancellationTokenSource = new();
 
@@ -237,5 +237,10 @@ public sealed partial class CreateNewImage : Microsoft.Build.Utilities.Task, ICa
 
     private void SafeLog(string message, params object[] formatParams) {
         if(BuildEngine != null) Log.LogMessage(MessageImportance.High, message, formatParams);
+    }
+
+    public void Dispose()
+    {
+        _cancellationTokenSource.Dispose();
     }
 }


### PR DESCRIPTION
I was looking towards support for `scratch` containers, and I reasoned that I still wanted to use the `ImageConfig` type to store all of the user-supplied information, but in the case of the 'scratch' image there would be no base config. Therefore some of the required properties in a configuration would need to be specified more manually. So I elevated them to first-class fields in the ImageConfig type.

As part of that, I got around to an item I've wanted to do for a while - adding a log to the History collection in the config to trace the fact that _we_ made one of the layers.

Here's what the history of one of our generated test containers looks like when viewed under `docker history <imagename>`:

![image](https://user-images.githubusercontent.com/573979/221325323-a51f2e77-0bd3-4986-a744-7ce31d08bdae.png)

Docker Desktop also has a more detailed view:

![image](https://user-images.githubusercontent.com/573979/221325363-9e3c9246-11d6-449d-8698-57beb55ba548.png)
