### PR TITLE
Add support for setting the `User` metadata item

### DIFF
--- a/Microsoft.NET.Build.Containers/ImageBuilder.cs
+++ b/Microsoft.NET.Build.Containers/ImageBuilder.cs
@@ -83,4 +83,6 @@ internal sealed class ImageBuilder
     /// Sets an entry point for the image.
     /// </summary>
     internal void SetEntryPoint(string[] executableArgs, string[]? args = null) => _baseImageConfig.SetEntryPoint(executableArgs, args);
+
+    internal void SetUser(string user) => _baseImageConfig.SetUser(user);
 }

--- a/Microsoft.NET.Build.Containers/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/Microsoft.NET.Build.Containers/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -30,6 +30,8 @@ Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ContainerizeDirectory.get ->
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ContainerizeDirectory.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ContainerRuntimeIdentifier.get -> string!
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ContainerRuntimeIdentifier.set -> void
+Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ContainerUser.get -> string!
+Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ContainerUser.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.CreateNewImage() -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.Entrypoint.get -> Microsoft.Build.Framework.ITaskItem![]!
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.Entrypoint.set -> void

--- a/Microsoft.NET.Build.Containers/PublicAPI/net7.0/PublicAPI.Unshipped.txt
+++ b/Microsoft.NET.Build.Containers/PublicAPI/net7.0/PublicAPI.Unshipped.txt
@@ -1,6 +1,7 @@
 ﻿const Microsoft.NET.Build.Containers.KnownDaemonTypes.Docker = "Docker" -> string!
 Microsoft.NET.Build.Containers.BaseImageNotFoundException
 Microsoft.NET.Build.Containers.Constants
+static Microsoft.NET.Build.Containers.ContainerBuilder.ContainerizeAsync(System.IO.DirectoryInfo! folder, string! workingDir, string! registryName, string! baseName, string! baseTag, string![]! entrypoint, string![]? entrypointArgs, string! imageName, string![]! imageTags, string? outputRegistry, string![]? labels, Microsoft.NET.Build.Containers.Port[]? exposedPorts, string![]? envVars, string! containerRuntimeIdentifier, string! ridGraphPath, string! localContainerDaemon, string? containerUser, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 static readonly Microsoft.NET.Build.Containers.Constants.Version -> string!
 Microsoft.NET.Build.Containers.ContainerBuilder
 Microsoft.NET.Build.Containers.ContainerHelpers
@@ -118,6 +119,8 @@ Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ContainerizeDirectory.get ->
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ContainerizeDirectory.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ContainerRuntimeIdentifier.get -> string!
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ContainerRuntimeIdentifier.set -> void
+Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ContainerUser.get -> string!
+Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ContainerUser.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.CreateNewImage() -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.Dispose() -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.Entrypoint.get -> Microsoft.Build.Framework.ITaskItem![]!
@@ -173,7 +176,6 @@ Microsoft.NET.Build.Containers.Tasks.ParseContainerProperties.ParsedContainerReg
 Microsoft.NET.Build.Containers.Tasks.ParseContainerProperties.ParsedContainerTag.get -> string!
 override Microsoft.NET.Build.Containers.Tasks.CreateNewImage.Execute() -> bool
 override Microsoft.NET.Build.Containers.Tasks.ParseContainerProperties.Execute() -> bool
-static Microsoft.NET.Build.Containers.ContainerBuilder.ContainerizeAsync(System.IO.DirectoryInfo! folder, string! workingDir, string! registryName, string! baseName, string! baseTag, string![]! entrypoint, string![]! entrypointArgs, string! imageName, string![]! imageTags, string? outputRegistry, string![]! labels, Microsoft.NET.Build.Containers.Port[]! exposedPorts, string![]! envVars, string! containerRuntimeIdentifier, string! ridGraphPath, string! localContainerDaemon, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 static Microsoft.NET.Build.Containers.ContainerHelpers.TryParsePort(string! input, out Microsoft.NET.Build.Containers.Port? port, out Microsoft.NET.Build.Containers.ContainerHelpers.ParsePortError? error) -> bool
 static Microsoft.NET.Build.Containers.ContainerHelpers.TryParsePort(string? portNumber, string? portType, out Microsoft.NET.Build.Containers.Port? port, out Microsoft.NET.Build.Containers.ContainerHelpers.ParsePortError? error) -> bool
 static readonly Microsoft.NET.Build.Containers.KnownDaemonTypes.SupportedLocalDaemonTypes -> string![]!

--- a/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.Interface.cs
+++ b/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.Interface.cs
@@ -114,6 +114,15 @@ partial class CreateNewImage
     [Required]
     public string RuntimeIdentifierGraphPath { get; set; }
 
+    /// <summary>
+    /// The username or UID which is a platform-specific structure that allows specific control over which user the process run as.
+    /// This acts as a default value to use when the value is not specified when creating a container.
+    /// For Linux based systems, all of the following are valid: user, uid, user:group, uid:gid, uid:group, user:gid.
+    /// If group/gid is not specified, the default group and supplementary groups of the given user/uid in /etc/passwd and /etc/group from the container are applied.
+    /// If group/gid is specified, supplementary groups from the container are ignored.
+    /// </summary>
+    public string ContainerUser { get; set; }
+
     [Output]
     public string GeneratedContainerManifest { get; set; }
 
@@ -141,6 +150,7 @@ partial class CreateNewImage
         ContainerRuntimeIdentifier = "";
         RuntimeIdentifierGraphPath = "";
         LocalContainerDaemon = "";
+        ContainerUser = "";
 
         GeneratedContainerConfiguration = "";
         GeneratedContainerManifest = "";

--- a/Microsoft.NET.Build.Containers/Tasks/CreateNewImageToolTask.cs
+++ b/Microsoft.NET.Build.Containers/Tasks/CreateNewImageToolTask.cs
@@ -113,7 +113,7 @@ public partial class CreateNewImage : ToolTask, ICancelableTask
         builder.AppendSwitchIfNotNull("--workingdirectory ", WorkingDirectory);
         ITaskItem[] sanitizedEntryPoints = Entrypoint.Where(e => !string.IsNullOrWhiteSpace(e.ItemSpec)).ToArray();
         builder.AppendSwitchIfNotNull("--entrypoint ", sanitizedEntryPoints, delimiter: " ");
- 
+
         //optional options
         if (!string.IsNullOrWhiteSpace(BaseImageTag))
         {
@@ -185,10 +185,17 @@ public partial class CreateNewImage : ToolTask, ICancelableTask
         {
             builder.AppendSwitchIfNotNull("--rid ", ContainerRuntimeIdentifier);
         }
+
         if (!string.IsNullOrWhiteSpace(RuntimeIdentifierGraphPath))
         {
             builder.AppendSwitchIfNotNull("--ridgraphpath ", RuntimeIdentifierGraphPath);
         }
+
+        if (!string.IsNullOrWhiteSpace(ContainerUser))
+        {
+            builder.AppendSwitchIfNotNull("--container-user ", ContainerUser);
+        }
+
         return builder.ToString();
     }
 

--- a/containerize/Program.cs
+++ b/containerize/Program.cs
@@ -6,7 +6,7 @@ using Microsoft.NET.Build.Containers;
 using System.CommandLine.Parsing;
 using System.Text;
 
-#pragma warning disable CA1852 
+#pragma warning disable CA1852
 
 var publishDirectoryArg = new Argument<DirectoryInfo>(
     name: "PublishDirectory",
@@ -164,6 +164,8 @@ var ridOpt = new Option<string>(name: "--rid", description: "Runtime Identifier 
 
 var ridGraphPathOpt = new Option<string>(name: "--ridgraphpath", description: "Path to the RID graph file.");
 
+var containerUserOpt = new Option<string>(name: "--container-user", description: "User to run the container as.");
+
 RootCommand root = new RootCommand("Containerize an application without Docker.")
 {
     publishDirectoryArg,
@@ -181,27 +183,29 @@ RootCommand root = new RootCommand("Containerize an application without Docker."
     envVarsOpt,
     ridOpt,
     ridGraphPathOpt,
-    localContainerDaemonOpt
+    localContainerDaemonOpt,
+    containerUserOpt
 };
 
 root.SetHandler(async (context) =>
 {
     DirectoryInfo _publishDir = context.ParseResult.GetValueForArgument(publishDirectoryArg);
-    string _baseReg = context.ParseResult.GetValueForOption(baseRegistryOpt) ?? "";
-    string _baseName = context.ParseResult.GetValueForOption(baseImageNameOpt) ?? "";
-    string _baseTag = context.ParseResult.GetValueForOption(baseImageTagOpt) ?? "";
+    string _baseReg = context.ParseResult.GetValueForOption(baseRegistryOpt)!;
+    string _baseName = context.ParseResult.GetValueForOption(baseImageNameOpt)!;
+    string _baseTag = context.ParseResult.GetValueForOption(baseImageTagOpt)!;
     string? _outputReg = context.ParseResult.GetValueForOption(outputRegistryOpt);
-    string _name = context.ParseResult.GetValueForOption(imageNameOpt) ?? "";
-    string[] _tags = context.ParseResult.GetValueForOption(imageTagsOpt) ?? Array.Empty<string>();
-    string _workingDir = context.ParseResult.GetValueForOption(workingDirectoryOpt) ?? "";
-    string[] _entrypoint = context.ParseResult.GetValueForOption(entrypointOpt) ?? Array.Empty<string>();
-    string[] _entrypointArgs = context.ParseResult.GetValueForOption(entrypointArgsOpt) ?? Array.Empty<string>();
-    string[] _labels = context.ParseResult.GetValueForOption(labelsOpt) ?? Array.Empty<string>();
-    Port[] _ports = context.ParseResult.GetValueForOption(portsOpt) ?? Array.Empty<Port>();
-    string[] _envVars = context.ParseResult.GetValueForOption(envVarsOpt) ?? Array.Empty<string>();
-    string _rid = context.ParseResult.GetValueForOption(ridOpt) ?? "";
-    string _ridGraphPath = context.ParseResult.GetValueForOption(ridGraphPathOpt) ?? "";
-    string _localContainerDaemon = context.ParseResult.GetValueForOption(localContainerDaemonOpt) ?? "";
+    string _name = context.ParseResult.GetValueForOption(imageNameOpt)!;
+    string[] _tags = context.ParseResult.GetValueForOption(imageTagsOpt)!;
+    string _workingDir = context.ParseResult.GetValueForOption(workingDirectoryOpt)!;
+    string[] _entrypoint = context.ParseResult.GetValueForOption(entrypointOpt)!;
+    string[]? _entrypointArgs = context.ParseResult.GetValueForOption(entrypointArgsOpt);
+    string[]? _labels = context.ParseResult.GetValueForOption(labelsOpt);
+    Port[]? _ports = context.ParseResult.GetValueForOption(portsOpt);
+    string[]? _envVars = context.ParseResult.GetValueForOption(envVarsOpt);
+    string _rid = context.ParseResult.GetValueForOption(ridOpt)!;
+    string _ridGraphPath = context.ParseResult.GetValueForOption(ridGraphPathOpt)!;
+    string _localContainerDaemon = context.ParseResult.GetValueForOption(localContainerDaemonOpt)!;
+    string? _containerUser = context.ParseResult.GetValueForOption(containerUserOpt);
     await ContainerBuilder.ContainerizeAsync(
         _publishDir,
         _workingDir,
@@ -219,6 +223,7 @@ root.SetHandler(async (context) =>
         _rid,
         _ridGraphPath,
         _localContainerDaemon,
+        _containerUser,
         context.GetCancellationToken()).ConfigureAwait(false);
 });
 

--- a/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -185,8 +185,9 @@
                     ExposedPorts="@(ContainerPort)"
                     ContainerEnvironmentVariables="@(ContainerEnvironmentVariables)"
                     ContainerRuntimeIdentifier="$(ContainerRuntimeIdentifier)"
+                    ContainerUser="$(ContainerUser)"
                     RuntimeIdentifierGraphPath="$(RuntimeIdentifierGraphPath)"> <!-- The RID graph path is provided as a property by the SDK. -->
-      
+
       <Output TaskParameter="GeneratedContainerManifest" PropertyName="GeneratedContainerManifest" />
       <Output TaskParameter="GeneratedContainerConfiguration" PropertyName="GeneratedContainerConfiguration" />
     </CreateNewImage>


### PR DESCRIPTION
There is no validation on this, as it's _very_ hard to do - the supported formats are

* user name
* user id
* user name:group name
* user id:group id
* user id:group name
* user name:group id

all of which should match either a name or an id from `/etc/passwd`, which we theoretically have access to through the layers, but that seems _really_ extra to acquire, unTAR, parse and validate.

Closes #115