### PR TITLE
Add tar.gz as new output option.

### DIFF
--- a/Microsoft.NET.Build.Containers/LocalDaemons/LocalDocker.cs
+++ b/Microsoft.NET.Build.Containers/LocalDaemons/LocalDocker.cs
@@ -152,7 +152,7 @@ internal sealed class LocalDocker : ILocalDaemon
         }
     }
 
-    private static async Task WriteImageToStreamAsync(BuiltImage image, ImageReference sourceReference, ImageReference destinationReference, Stream imageStream, CancellationToken cancellationToken)
+    internal static async Task WriteImageToStreamAsync(BuiltImage image, ImageReference sourceReference, ImageReference destinationReference, Stream imageStream, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
         using TarWriter writer = new(imageStream, TarEntryFormat.Pax, leaveOpen: true);

--- a/Microsoft.NET.Build.Containers/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/Microsoft.NET.Build.Containers/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -41,6 +41,8 @@ Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GeneratedContainerConfigurat
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GeneratedContainerConfiguration.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GeneratedContainerManifest.get -> string!
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GeneratedContainerManifest.set -> void
+Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GeneratedTars.get -> Microsoft.Build.Framework.ITaskItem![]!
+Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GeneratedTars.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ImageName.get -> string!
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ImageName.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ImageTags.get -> string![]!
@@ -55,6 +57,8 @@ Microsoft.NET.Build.Containers.Tasks.CreateNewImage.PublishDirectory.get -> stri
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.PublishDirectory.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.RuntimeIdentifierGraphPath.get -> string!
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.RuntimeIdentifierGraphPath.set -> void
+Microsoft.NET.Build.Containers.Tasks.CreateNewImage.TarOutputDirectory.get -> string!
+Microsoft.NET.Build.Containers.Tasks.CreateNewImage.TarOutputDirectory.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.WorkingDirectory.get -> string!
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.WorkingDirectory.set -> void
 override Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ToolName.get -> string!

--- a/Microsoft.NET.Build.Containers/PublicAPI/net7.0/PublicAPI.Unshipped.txt
+++ b/Microsoft.NET.Build.Containers/PublicAPI/net7.0/PublicAPI.Unshipped.txt
@@ -127,6 +127,8 @@ Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GeneratedContainerConfigurat
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GeneratedContainerConfiguration.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GeneratedContainerManifest.get -> string!
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GeneratedContainerManifest.set -> void
+Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GeneratedTars.get -> Microsoft.Build.Framework.ITaskItem![]!
+Microsoft.NET.Build.Containers.Tasks.CreateNewImage.GeneratedTars.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ImageName.get -> string!
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ImageName.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ImageTags.get -> string![]!
@@ -141,6 +143,8 @@ Microsoft.NET.Build.Containers.Tasks.CreateNewImage.PublishDirectory.get -> stri
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.PublishDirectory.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.RuntimeIdentifierGraphPath.get -> string!
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.RuntimeIdentifierGraphPath.set -> void
+Microsoft.NET.Build.Containers.Tasks.CreateNewImage.TarOutputDirectory.get -> string!
+Microsoft.NET.Build.Containers.Tasks.CreateNewImage.TarOutputDirectory.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ToolExe.get -> string!
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ToolExe.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ToolPath.get -> string!
@@ -170,7 +174,7 @@ Microsoft.NET.Build.Containers.Tasks.ParseContainerProperties.ParsedContainerReg
 Microsoft.NET.Build.Containers.Tasks.ParseContainerProperties.ParsedContainerTag.get -> string!
 override Microsoft.NET.Build.Containers.Tasks.CreateNewImage.Execute() -> bool
 override Microsoft.NET.Build.Containers.Tasks.ParseContainerProperties.Execute() -> bool
-static Microsoft.NET.Build.Containers.ContainerBuilder.ContainerizeAsync(System.IO.DirectoryInfo! folder, string! workingDir, string! registryName, string! baseName, string! baseTag, string![]! entrypoint, string![]! entrypointArgs, string! imageName, string![]! imageTags, string? outputRegistry, string![]! labels, Microsoft.NET.Build.Containers.Port[]! exposedPorts, string![]! envVars, string! containerRuntimeIdentifier, string! ridGraphPath, string! localContainerDaemon, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+static Microsoft.NET.Build.Containers.ContainerBuilder.ContainerizeAsync(System.IO.DirectoryInfo! folder, string! workingDir, string! registryName, string! baseName, string! baseTag, string![]! entrypoint, string![]! entrypointArgs, string! imageName, string![]! imageTags, string? outputRegistry, string![]! labels, Microsoft.NET.Build.Containers.Port[]! exposedPorts, string![]! envVars, string! containerRuntimeIdentifier, string! ridGraphPath, string! localContainerDaemon, string? tarOutputDirectory, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 static Microsoft.NET.Build.Containers.ContainerHelpers.TryParsePort(string! input, out Microsoft.NET.Build.Containers.Port? port, out Microsoft.NET.Build.Containers.ContainerHelpers.ParsePortError? error) -> bool
 static Microsoft.NET.Build.Containers.ContainerHelpers.TryParsePort(string? portNumber, string? portType, out Microsoft.NET.Build.Containers.Port? port, out Microsoft.NET.Build.Containers.ContainerHelpers.ParsePortError? error) -> bool
 static readonly Microsoft.NET.Build.Containers.KnownDaemonTypes.SupportedLocalDaemonTypes -> string![]!

--- a/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.Interface.cs
+++ b/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.Interface.cs
@@ -44,6 +44,17 @@ partial class CreateNewImage
     public string OutputRegistry { get; set; }
 
     /// <summary>
+    /// The directory into which to write the generated tar.gz files.
+    /// </summary>
+    public string TarOutputDirectory { get; set; }
+
+    /// <summary>
+    /// All tar.gz files which were produced as outputs in case TarOutputDirectory is used.
+    /// </summary>
+    [Output]
+    public ITaskItem[] GeneratedTars { get; set; }
+
+    /// <summary>
     /// The kind of local daemon to use, if any.
     /// </summary>
     [Required]
@@ -129,6 +140,7 @@ partial class CreateNewImage
         BaseImageName = "";
         BaseImageTag = "";
         OutputRegistry = "";
+        TarOutputDirectory = "";
         ImageName = "";
         ImageTags = Array.Empty<string>();
         PublishDirectory = "";
@@ -138,6 +150,7 @@ partial class CreateNewImage
         Labels = Array.Empty<ITaskItem>();
         ExposedPorts = Array.Empty<ITaskItem>();
         ContainerEnvironmentVariables = Array.Empty<ITaskItem>();
+        GeneratedTars = Array.Empty<ITaskItem>();
         ContainerRuntimeIdentifier = "";
         RuntimeIdentifierGraphPath = "";
         LocalContainerDaemon = "";

--- a/containerize/Program.cs
+++ b/containerize/Program.cs
@@ -6,7 +6,7 @@ using Microsoft.NET.Build.Containers;
 using System.CommandLine.Parsing;
 using System.Text;
 
-#pragma warning disable CA1852 
+#pragma warning disable CA1852
 
 var publishDirectoryArg = new Argument<DirectoryInfo>(
     name: "PublishDirectory",
@@ -35,6 +35,13 @@ var baseImageTagOpt = new Option<string>(
 var outputRegistryOpt = new Option<string>(
     name: "--outputregistry",
     description: "The registry to push to.")
+{
+    IsRequired = false
+};
+
+var tarOutputDirectoryOpt = new Option<string>(
+    name: "--taroutputdirectory",
+    description: "The directory into which to write the generated tar.gz files.")
 {
     IsRequired = false
 };
@@ -171,6 +178,7 @@ RootCommand root = new RootCommand("Containerize an application without Docker."
     baseImageNameOpt,
     baseImageTagOpt,
     outputRegistryOpt,
+    tarOutputDirectoryOpt,
     imageNameOpt,
     imageTagsOpt,
     workingDirectoryOpt,
@@ -191,6 +199,7 @@ root.SetHandler(async (context) =>
     string _baseName = context.ParseResult.GetValueForOption(baseImageNameOpt) ?? "";
     string _baseTag = context.ParseResult.GetValueForOption(baseImageTagOpt) ?? "";
     string? _outputReg = context.ParseResult.GetValueForOption(outputRegistryOpt);
+    string? _tarOutputDirectory = context.ParseResult.GetValueForOption(tarOutputDirectoryOpt);
     string _name = context.ParseResult.GetValueForOption(imageNameOpt) ?? "";
     string[] _tags = context.ParseResult.GetValueForOption(imageTagsOpt) ?? Array.Empty<string>();
     string _workingDir = context.ParseResult.GetValueForOption(workingDirectoryOpt) ?? "";
@@ -219,6 +228,7 @@ root.SetHandler(async (context) =>
         _rid,
         _ridGraphPath,
         _localContainerDaemon,
+        _tarOutputDirectory,
         context.GetCancellationToken()).ConfigureAwait(false);
 });
 

--- a/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -175,6 +175,7 @@
                     BaseImageTag="$(ContainerBaseTag)"
                     LocalContainerDaemon="$(LocalContainerDaemon)"
                     OutputRegistry="$(ContainerRegistry)"
+                    TarOutputDirectory="$(TarOutputDirectory)"
                     ImageName="$(ContainerImageName)"
                     ImageTags="@(ContainerImageTags)"
                     PublishDirectory="$(PublishDir)"


### PR DESCRIPTION
Resolves #283 

> ℹ️ At this point this PR is still a draft/proposal for further discussion before finalizing it. 

In this proposal some new options would allow the writing of tar.gz files as output. Essential changes: 

* New `TarOutputDirectory` parameter which would activate the tar.gz writing. 
* New `OutputMode` which allows more specific control of which output flow to follow (local daemon, remote push, file writing). 

**Pending change until approval of approach:** writing tests. 

**Alternative proposal:** Use the new "local daemon" feature to have something like a fake "tar" Daemon. Unfortunately at this point I am lacking an option to then pass in the folder into which to write the tarballs. And also the output property on the Task would be missing in this case unless we extend it. Would need some confirmation on the desired public API for this feature. 