### PR TITLE
Fix JFROG Artifactory Compatibility

### DIFF
--- a/Microsoft.NET.Build.Containers.UnitTests/ImageBuilderTests.cs
+++ b/Microsoft.NET.Build.Containers.UnitTests/ImageBuilderTests.cs
@@ -290,4 +290,88 @@ public class ImageBuilderTests
         Assert.NotNull(resultPorts["6100/tcp"] as JsonObject);
         Assert.NotNull(resultPorts["6200/tcp"] as JsonObject);
     }
+
+    [InlineData(true)]
+    [InlineData(false)]
+    [Theory]
+    public void CanOmitAndKeepHistory(bool omitHistory)
+    {
+        string simpleImageConfig =
+            """
+                {
+                    "architecture": "amd64",
+                    "config": {
+                      "Hostname": "",
+                      "Domainname": "",
+                      "User": "",
+                      "AttachStdin": false,
+                      "AttachStdout": false,
+                      "AttachStderr": false,
+                      "Tty": false,
+                      "OpenStdin": false,
+                      "StdinOnce": false,
+                      "Env": [
+                        "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+                        "ASPNETCORE_URLS=http://+:80",
+                        "DOTNET_RUNNING_IN_CONTAINER=true",
+                        "DOTNET_VERSION=7.0.2",
+                        "ASPNET_VERSION=7.0.2"
+                      ],
+                      "Cmd": ["bash"],
+                      "Image": "sha256:d772d27ebeec80393349a4770dc37f977be2c776a01c88b624d43f93fa369d69",
+                      "Volumes": null,
+                      "WorkingDir": "",
+                      "Entrypoint": null,
+                      "OnBuild": null,
+                      "Labels": null,
+                      "ExposedPorts":
+                      {
+                        "6100/tcp": {},
+                        "6200": {}
+                      }
+                    },
+                    "created": "2023-02-04T08:14:52.000901321Z",
+                    "os": "linux",
+                    "rootfs": {
+                      "type": "layers",
+                      "diff_ids": [
+                        "sha256:bd2fe8b74db65d82ea10db97368d35b92998d4ea0e7e7dc819481fe4a68f64cf",
+                        "sha256:94100d1041b650c6f7d7848c550cd98c25d0bdc193d30692e5ea5474d7b3b085",
+                        "sha256:53c2a75a33c8f971b4b5036d34764373e134f91ee01d8053b4c3573c42e1cf5d",
+                        "sha256:49a61320e585180286535a2545be5722b09e40ad44c7c190b20ec96c9e42e4a3",
+                        "sha256:8a379cce2ac272aa71aa029a7bbba85c852ba81711d9f90afaefd3bf5036dc48"
+                      ]
+                    },
+                    "history": [{
+                        "created": "2023-03-01T04:09:58.669479866Z",
+                        "created_by": "/bin/sh -c #(nop) ADD file:493a5b0c8d2d63a1343258b3f9aa5fcd59a93f44fe26ad9e56b094c3a08fd3be in / "
+                    }, {
+                        "created": "2023-03-01T04:09:59.032972609Z",
+                        "created_by": "/bin/sh -c #(nop)  CMD [\u0022bash\u0022]",
+                        "empty_layer": true
+                    }]
+                }
+                """;
+
+        JsonNode? node = JsonNode.Parse(simpleImageConfig);
+        Assert.NotNull(node);
+
+        ImageConfig baseConfig = new ImageConfig(node);
+
+        baseConfig.SetOmitHistory(omitHistory);
+
+        string readyImage = baseConfig.BuildConfig();
+
+        JsonNode? result = JsonNode.Parse(readyImage);
+
+        var historyNode = result?["history"];
+        if (omitHistory)
+        {
+            Assert.Null(historyNode);
+        }
+        else
+        {
+            Assert.NotNull(historyNode);
+        }
+    }
 }

--- a/Microsoft.NET.Build.Containers/ContainerBuilder.cs
+++ b/Microsoft.NET.Build.Containers/ContainerBuilder.cs
@@ -26,6 +26,7 @@ public static class ContainerBuilder
         string ridGraphPath,
         string localContainerDaemon,
         string? containerUser,
+        bool containerOmitHistory,
         CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -82,6 +83,8 @@ public static class ContainerBuilder
         {
             imageBuilder.SetUser(user);
         }
+
+        imageBuilder.SetOmitHistory(containerOmitHistory);
 
         BuiltImage builtImage = imageBuilder.Build();
 

--- a/Microsoft.NET.Build.Containers/ImageBuilder.cs
+++ b/Microsoft.NET.Build.Containers/ImageBuilder.cs
@@ -90,4 +90,15 @@ internal sealed class ImageBuilder
     internal void SetEntryPoint(string[] executableArgs, string[]? args = null) => _baseImageConfig.SetEntryPoint(executableArgs, args);
 
     internal void SetUser(string user) => _baseImageConfig.SetUser(user);
+
+    /// <summary>
+    /// Sets whether the history should be omitted from the final configuration.
+    /// </summary>
+    /// <param name="omitHistory">true if the hihstory should be omitted, otherwise false</param>
+    /// <remarks>
+    /// Some registries like JFROG Artifactory, have problems with handling the history, this option allowes
+    /// compatibility with them.
+    /// </remarks>
+    internal void SetOmitHistory(bool omitHistory) => _baseImageConfig.SetOmitHistory(omitHistory);
+
 }

--- a/Microsoft.NET.Build.Containers/ImageConfig.cs
+++ b/Microsoft.NET.Build.Containers/ImageConfig.cs
@@ -26,6 +26,7 @@ internal sealed class ImageConfig
     private readonly string _architecture;
     private readonly string _os;
     private readonly List<HistoryEntry> _history;
+    private bool _omitHistory;
 
     /// <summary>
     /// Gets a value indicating whether the base image is has a Windows operating system.
@@ -134,6 +135,11 @@ internal sealed class ImageConfig
             ["history"] = new JsonArray(_history.Select(CreateHistory).ToArray()),
         };
 
+        if (_omitHistory)
+        {
+            configContainer.Remove("history");
+        }
+
         return configContainer.ToJsonString();
 
         static JsonArray ToJsonArray(IEnumerable<string> items) => new(items.Where(s => !string.IsNullOrEmpty(s)).Select(s => JsonValue.Create(s)).ToArray());
@@ -200,6 +206,12 @@ internal sealed class ImageConfig
     }
 
     internal void SetUser(string user) => _user = user;
+
+
+    public void SetOmitHistory(bool omitHistory)
+    {
+        _omitHistory = omitHistory;
+    }
 
     private HashSet<Port> GetExposedPorts()
     {

--- a/Microsoft.NET.Build.Containers/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/Microsoft.NET.Build.Containers/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -32,6 +32,8 @@ Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ContainerRuntimeIdentifier.g
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ContainerRuntimeIdentifier.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ContainerUser.get -> string!
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ContainerUser.set -> void
+Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ContainerOmitHistory.get -> bool
+Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ContainerOmitHistory.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.CreateNewImage() -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.Entrypoint.get -> Microsoft.Build.Framework.ITaskItem![]!
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.Entrypoint.set -> void

--- a/Microsoft.NET.Build.Containers/PublicAPI/net7.0/PublicAPI.Unshipped.txt
+++ b/Microsoft.NET.Build.Containers/PublicAPI/net7.0/PublicAPI.Unshipped.txt
@@ -1,7 +1,7 @@
 ﻿const Microsoft.NET.Build.Containers.KnownDaemonTypes.Docker = "Docker" -> string!
 Microsoft.NET.Build.Containers.BaseImageNotFoundException
 Microsoft.NET.Build.Containers.Constants
-static Microsoft.NET.Build.Containers.ContainerBuilder.ContainerizeAsync(System.IO.DirectoryInfo! folder, string! workingDir, string! registryName, string! baseName, string! baseTag, string![]! entrypoint, string![]? entrypointArgs, string! imageName, string![]! imageTags, string? outputRegistry, string![]? labels, Microsoft.NET.Build.Containers.Port[]? exposedPorts, string![]? envVars, string! containerRuntimeIdentifier, string! ridGraphPath, string! localContainerDaemon, string? containerUser, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+static Microsoft.NET.Build.Containers.ContainerBuilder.ContainerizeAsync(System.IO.DirectoryInfo! folder, string! workingDir, string! registryName, string! baseName, string! baseTag, string![]! entrypoint, string![]? entrypointArgs, string! imageName, string![]! imageTags, string? outputRegistry, string![]? labels, Microsoft.NET.Build.Containers.Port[]? exposedPorts, string![]? envVars, string! containerRuntimeIdentifier, string! ridGraphPath, string! localContainerDaemon, string? containerUser, bool containerOmitHistory, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 static readonly Microsoft.NET.Build.Containers.Constants.Version -> string!
 Microsoft.NET.Build.Containers.ContainerBuilder
 Microsoft.NET.Build.Containers.ContainerHelpers
@@ -121,6 +121,8 @@ Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ContainerRuntimeIdentifier.g
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ContainerRuntimeIdentifier.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ContainerUser.get -> string!
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ContainerUser.set -> void
+Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ContainerOmitHistory.get -> bool
+Microsoft.NET.Build.Containers.Tasks.CreateNewImage.ContainerOmitHistory.set -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.CreateNewImage() -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.Dispose() -> void
 Microsoft.NET.Build.Containers.Tasks.CreateNewImage.Entrypoint.get -> Microsoft.Build.Framework.ITaskItem![]!

--- a/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.Interface.cs
+++ b/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.Interface.cs
@@ -123,6 +123,13 @@ partial class CreateNewImage
     /// </summary>
     public string ContainerUser { get; set; }
 
+    /// <summary>
+    /// Whether to omit the history from the container configuration which might be required for
+    /// registry compatibility as the default generated history is not a fully valid one to create
+    /// reproducible builds.
+    /// </summary>
+    public bool ContainerOmitHistory { get; set; }
+
     [Output]
     public string GeneratedContainerManifest { get; set; }
 
@@ -151,6 +158,7 @@ partial class CreateNewImage
         RuntimeIdentifierGraphPath = "";
         LocalContainerDaemon = "";
         ContainerUser = "";
+        ContainerOmitHistory = false;
 
         GeneratedContainerConfiguration = "";
         GeneratedContainerManifest = "";

--- a/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
+++ b/Microsoft.NET.Build.Containers/Tasks/CreateNewImage.cs
@@ -69,6 +69,7 @@ public sealed partial class CreateNewImage : Microsoft.Build.Utilities.Task, ICa
         Layer newLayer = Layer.FromDirectory(PublishDirectory, WorkingDirectory, imageBuilder.IsWindows);
         imageBuilder.AddLayer(newLayer);
         imageBuilder.SetWorkingDirectory(WorkingDirectory);
+        imageBuilder.SetOmitHistory(ContainerOmitHistory);
         imageBuilder.SetEntryPoint(Entrypoint.Select(i => i.ItemSpec).ToArray(), EntrypointArgs.Select(i => i.ItemSpec).ToArray());
 
         foreach (ITaskItem label in Labels)

--- a/Microsoft.NET.Build.Containers/Tasks/CreateNewImageToolTask.cs
+++ b/Microsoft.NET.Build.Containers/Tasks/CreateNewImageToolTask.cs
@@ -196,6 +196,8 @@ public partial class CreateNewImage : ToolTask, ICancelableTask
             builder.AppendSwitchIfNotNull("--container-user ", ContainerUser);
         }
 
+        builder.AppendSwitchIfNotNull("--container-omit-history", ContainerOmitHistory.ToString().ToLowerInvariant());
+
         return builder.ToString();
     }
 

--- a/containerize/Program.cs
+++ b/containerize/Program.cs
@@ -164,7 +164,10 @@ var ridOpt = new Option<string>(name: "--rid", description: "Runtime Identifier 
 
 var ridGraphPathOpt = new Option<string>(name: "--ridgraphpath", description: "Path to the RID graph file.");
 
-var containerUserOpt = new Option<string>(name: "--container-user", description: "User to run the container as.");
+var containerUserOpt = new Option<string>(name: "--container-user", description: "Whether to omit the history from the container configuration.");
+var containerOmitHistoryOpt = new Option<bool>(name: "--container-omit-history",
+    description: "Whether to omit the history from the container configuration.",
+    getDefaultValue: () => false);
 
 RootCommand root = new RootCommand("Containerize an application without Docker.")
 {
@@ -206,6 +209,7 @@ root.SetHandler(async (context) =>
     string _ridGraphPath = context.ParseResult.GetValueForOption(ridGraphPathOpt)!;
     string _localContainerDaemon = context.ParseResult.GetValueForOption(localContainerDaemonOpt)!;
     string? _containerUser = context.ParseResult.GetValueForOption(containerUserOpt);
+    bool _containerOmitHistory = context.ParseResult.GetValueForOption(containerOmitHistoryOpt);
     await ContainerBuilder.ContainerizeAsync(
         _publishDir,
         _workingDir,
@@ -224,6 +228,7 @@ root.SetHandler(async (context) =>
         _ridGraphPath,
         _localContainerDaemon,
         _containerUser,
+        _containerOmitHistory,
         context.GetCancellationToken()).ConfigureAwait(false);
 });
 

--- a/packaging/build/Microsoft.NET.Build.Containers.targets
+++ b/packaging/build/Microsoft.NET.Build.Containers.targets
@@ -60,6 +60,8 @@
       <!-- An empty ContainerRegistry implies pushing to the local daemon, putting this here for documentation purposes -->
       <!-- <ContainerRegistry></ContainerRegistry> -->
 
+      <ContainerOmitHistory Condition=" '$(ContainerOmitHistory)' == '' ">false</ContainerOmitHistory>
+
       <!-- Set which local container daemon to use. We only explicitly support Docker (or things that mimic Docker APIs and binary names) at the moment. -->
       <LocalContainerDaemon Condition="'$(LocalContainerDaemon)' == ''">Docker</LocalContainerDaemon>
 
@@ -189,6 +191,7 @@
                     ContainerEnvironmentVariables="@(ContainerEnvironmentVariables)"
                     ContainerRuntimeIdentifier="$(ContainerRuntimeIdentifier)"
                     ContainerUser="$(ContainerUser)"
+                    ContainerOmitHistory="$(ContainerOmitHistory)"
                     RuntimeIdentifierGraphPath="$(RuntimeIdentifierGraphPath)"> <!-- The RID graph path is provided as a property by the SDK. -->
 
       <Output TaskParameter="GeneratedContainerManifest" PropertyName="GeneratedContainerManifest" />


### PR DESCRIPTION
Resolves #382 

This PR enables compatibility with [JFROG Artifactory docker registries](https://www.jfrog.com/confluence/display/JFROG/Docker+Registry) to push images. 

There are two compat issues: 

* Artifactory parses the history of the layer config. This parsing seems buggy which leads to the manifest to be rejected. A new option allows omitting of the history in the config. Auto detecting would require a workflow change that we contact the registries before we start building the image. 
* The `Accept` HTTP header is validated on certain API calls which leads to failed pushes. I changed to only provide the headers on pull/load related API calls. 

I tested the changes against our company internal Artifactory instance by adapting the `EndToEndTests.ApiEndToEndWithRegistryPushAndPull` and I can successfully push against our registry: 

![image](https://user-images.githubusercontent.com/674916/223702623-5431f015-c9ac-414a-a523-a71f356befc3.png)


